### PR TITLE
Edit SDG13 (WoS) - 13.3

### DIFF
--- a/SDG13_query_action_WoS.md
+++ b/SDG13_query_action_WoS.md
@@ -282,7 +282,7 @@ TS=
     OR "green climate fund" OR "Least Developed Countries Fund" OR "LDCF" OR "Special Climate Change Fund" OR "SCCF" OR "adaptation fund"
     OR "strategy" OR "initiative$"
     )  
-    NEAR/5  
+    NEAR/15  
         (      
           (
             ("climate" 

--- a/SDG13_query_action_WoS.md
+++ b/SDG13_query_action_WoS.md
@@ -252,71 +252,95 @@ TS=
 >
 >13.3.1 Extent to which (i) global citizenship education and (ii) education for sustainable development are mainstreamed in (a) national education policies; (b) curricula; (c) teacher education; and (d) student assessment
 
-This target is considered to cover research about improving education, awareness and capacity about climate change mitigation, adaptation,  impact reduction and early warning.
+This target is considered to cover research about improving climate change mitigation, adaptation, impact reduction and early warning. 
 
-This query consists of 1 phrase. The general structure is *action + education/awareness/capacity + climate mit/adapt/warning*
+In the first revision (v1.0.0), this target was originally considered to cover research about improving **capacity** for climate change mitigation, adaptation, impact reduction and early warning. We tried to limit to research about capacity by combining *capacity terms* (e.g. `education`, `infrastructure$`, `capacity`, `tools` etc.) with *climate mitigation/adapt/warning terms*. However, feedback and testing showed that this was a bit too restrictive. We lost a lot of relevant works about, for example, soil management to reduce emissions and capture carbon; adaptation of crop varieties to climate change; CO2 storage technologies. Therefore we have now dropped the terms around capacity, on the assumption that research itself generates capacity in the form of knowledge, tools, technologies and infrastructures. 
+
+This query consists of 1 phrase. The general structure is *action + climate mit/adapt/warning*
 
 Interpretation of what should be considered as contributing to raising "human and institutional capacity" is challenging - according to the UNDG definition, it concerns anything that would increase the ability of people and institutions to successfully manage the situation. We have interpreted this to include improvements in areas such as technology, infrastructure, research, skills, and knowledge, in addition to institutional structures, practices and resources. Allocation, awareness or understanding of responsibilities can also be important in capacity. Awareness is included explicitly in some definitions.
 * Definition of "capacity": "[...] the ability of people, organizations and society as a whole to manage their affairs successfully" (<a id="UNDGcapacity">[United Nations Development Group 2017](#f2)</a>).
 * Definition of "capacity development": "the process whereby people, organizations and society as a whole unleash, strengthen, create, adapt, and maintain capacity over time, in order to achieve development results" (<a id="UNDGcapacity">[United Nations Development Group 2017](#f2)</a>).
 * "Awareness raising and knowledge building about the expected impacts of a changing climate and the need to adapt are normally starting point of capacity building efforts". (On capacity building for adaptation; <a id="climateADAPT">[Climate-ADAPT 2019](#f6)</a>).
 
-For the *climate* terms, we include general terms about climate change mitigation/ adaption/ impact reduction/ early warning as well as the reduction of greenhouse gases (as a main method of climate change mitigation).
+We include general terms about climate change mitigation/ adaption/ impact reduction/ early warning as well as the reduction of greenhouse gases (as a main method of climate change mitigation). In addition to generic terms for greenhouse gases, we use six main greenhouse gases (covered by the Kyoto Protocol; <a id="IPCC2014">[IPCC 2014](#f3)</a>), some of which are combined with *climate change* as these gases, when used alone with `reduc*`, find some chemical results (e.g. a reaction for methane reduction).
 
 In the *action* terms, `increase` is not truncated as there are many works that begin with generic phrases such as "there is an increasing awareness of [research issue]". We include investing as an "action" in the sense that it can drive action (e.g. cooperation fund for education). We have also included specialist funds such as the [Green climate fund](https://www.greenclimate.fund/).
 
-In this string, sometimes the same terms appear in two parts (e.g. awareness). This is because these terms are likely sufficient alone (e.g. increase climate awareness), while others need an additional element (e.g. improve curricula for climate action - we need climate "action" to avoid e.g. improving university curricula for basic climate science).
 
 ```py
 TS=
 (
-    (
-      ("improv*" OR "increase" OR "better" OR "enhanc*" OR "build*" OR "strengthen*" OR "raise" OR "raising"
-      OR "develop" OR "developing" OR "create" OR "creation" OR "implement*" OR "integrat*" OR "adopt*"
-      OR "invest" OR "investing" OR "fund$" OR "funding"
-      OR "development assistance" OR "development aid" OR "development fund*" OR "foreign aid" OR "international aid" OR "cooperation fund*"
-      OR "financial assistance" OR "financial support" OR "economic assistance" OR "economic support"
-      OR "climate aid" OR "climate financ*" OR "climate fund*"
-      OR "green climate fund" OR "Least Developed Countries Fund" OR "LDCF" OR "Special Climate Change Fund" OR "SCCF" OR "adaptation fund"
-      OR "strategy" OR "initiative$"
-      )
-      NEAR/5
-          ("capacity" OR "capabilit*"
-          OR "educat*" OR "curriculum" OR "curricula" OR "teacher training" OR "climate literacy"
-          OR "research" OR "knowledge" OR "skills" OR "tools" OR "competenc*" OR "expertise" OR "training"
-          OR "awareness" OR "responsibilit*"
-          OR "infrastructure$" OR "technolog*" OR "early warning system$"
-          OR "communication" OR "collaboration" OR "cooperation" OR "co operation" OR "social network$" OR "information network$"
-          OR "economic resources" OR "financial resources" OR "human resource$"
-          OR (("institutional" OR "administrative" OR "policy" OR "governance") NEAR/5 ("structure$" OR "values" OR "practices" OR "arrangement$" OR "resources"))
-          )
+    ("improv*" OR "increase" OR "better" OR "enhanc*" OR "build*" OR "strengthen*" OR "raise" OR "raising"
+    OR "develop" OR "developing" OR "create" OR "creation" OR "implement*" OR "integrat*" OR "adopt*"
+    OR "invest" OR "investing" OR "fund$" OR "funding"
+    OR "development assistance" OR "development aid" OR "development fund*" OR "foreign aid" OR "international aid" OR "cooperation fund*"
+    OR "financial assistance" OR "financial support" OR "economic assistance" OR "economic support"
+    OR "climate aid" OR "climate financ*" OR "climate fund*"
+    OR "green climate fund" OR "Least Developed Countries Fund" OR "LDCF" OR "Special Climate Change Fund" OR "SCCF" OR "adaptation fund"
+    OR "strategy" OR "initiative$"
     )  
-  NEAR/15      
-      (
-        (
-          ("climate" OR "global warming" OR "climatic change$" OR "sea level rise")
-          NEAR/5  
-              ("action$" OR "sustainab*" OR "mitigat*" OR "adapt*" OR "cope" OR "coping" OR "resilien*"
-              OR "early warning" OR "warning system$" OR "preparedness" OR "risk$" OR "vulnerab*"
-              OR "awareness" OR "climate education" OR "climate sensitive education" OR "climate change education" OR "climate literacy"
-              OR "solutions" OR "problems"
-              OR
-                (
-                  ("reduc*" OR "minimi*" OR "decreas*" OR "limit" OR "alleviat*")
-                  NEAR/2 ("impact$" OR "effect$" OR "consequence$")        
+    NEAR/5  
+        (      
+          (
+            ("climate" 
+            OR "climate change" OR "climate warming" OR "warming climate" OR "global warming" OR "climatic change$" 
+            OR "climate emergency" OR "climate smart" OR "climate crisis"
+            OR "sea level rise" OR "rising sea level$"
+            )
+            NEAR/5  
+                ("action$" OR "mitigat*" OR "resilien*" OR "climate adapt*" OR "adaptive capacity" OR "capacity to adapt"
+                OR "early warning" OR "warning system$" OR "preparedness" OR "risk$" OR "vulnerab*"
+                OR "awareness" OR "climate education" OR "climate sensitive education" OR "climate change education" OR "climate literacy"
+                OR "solutions" OR "problems"
+                OR
+                  (
+                    ("reduc*" OR "minimi*" OR "decreas*" OR "limit" OR "alleviat*")
+                    NEAR/2 ("impact$" OR "effect$" OR "consequence$")        
+                  )
                 )
-              )
-        )
+          )
+        OR
+          (
+            ("climate change" OR "climate warming" OR "warming climate" OR "global warming" OR "climatic change$" 
+            OR "climate emergency" OR "climate smart" OR "climate crisis"
+            OR "sea level rise" OR "rising sea level$"
+            )
+            NEAR/5 ("sustainab*" OR "adapt*" OR "cope" OR "coping")
+          )
         OR
           (
             ("reduc*" OR "minimi*" OR "limit" OR "limiting" OR "decreas*" OR "lower" OR "mitigat*"
             OR "alleviat*" OR "tackl*" OR "combat*" OR "prevent*" OR "stop*" OR "avoid*"
+            OR "capture" OR "storage" OR "sequestration"
             )
-              NEAR/5
-                  ("GHG" OR "greenhouse gas" OR "greenhouse gases" OR "carbon footprint" OR "CO2 footprint" OR "carbon emission$" OR "CO2 emission$")
-          )   
-      )
+            NEAR/5 ("GHG" OR "greenhouse gas" OR "greenhouse gases" OR "carbon footprint" OR "CO2 footprint" OR "carbon emission$" OR "CO2 emission$")
+          )
+        OR 
+          (
+            (
+              ("reduc*" OR "minimi*" OR "limit" OR "limiting" OR "decreas*" OR "lower" OR "mitigat*"
+              OR "alleviat*" OR "tackl*" OR "combat*" OR "prevent*" OR "stop*" OR "avoid*"
+              OR "capture" OR "storage" OR "sequestration"
+              )
+              NEAR/3
+                  ("methane" OR "CH4" 
+                  OR "nitrous oxide" OR "NOX" OR "N2O" 
+                  OR "carbon dioxide" OR "CO2" 
+                  OR "hydrofluorocarbons" OR "HFCs" OR "perfluorocarbons" OR "PFCs" 
+                  OR "sulphur hexafluoride" OR "sulfur hexafluoride" OR "SF6"
+                  )
+            )
+          NEAR/15 ("climate change" OR "global warming" OR "climatic change$" OR "sea level rise" OR "rising sea level$" OR "climate emergency" OR "climate smart" OR "climate crisis")
+          )  
+    )
 )
+NOT 
+TS=
+  (
+    ("motivational climate" OR "organi$ational climate" OR "safety climate" OR "learning climate" OR "education climate") 
+    NOT("climate change" OR "climate crisis" OR "global warming" OR "climatic change$" OR "sea level rise" OR "rising sea level$")
+  )
 
 ```
 

--- a/SDG13_query_action_WoS.md
+++ b/SDG13_query_action_WoS.md
@@ -267,6 +267,8 @@ We include general terms about climate change mitigation/ adaption/ impact reduc
 
 In the *action* terms, `increase` is not truncated as there are many works that begin with generic phrases such as "there is an increasing awareness of [research issue]". We include investing as an "action" in the sense that it can drive action (e.g. cooperation fund for education). We have also included specialist funds such as the [Green climate fund](https://www.greenclimate.fund/).
 
+A double `NOT` phrase is added at the end to remove unrelated works using "climate" in a metaphorical way (e.g. "motivational climate"), unrelated to climate change.
+
 
 ```py
 TS=

--- a/SDG13_query_action_WoS.md
+++ b/SDG13_query_action_WoS.md
@@ -273,7 +273,7 @@ A double `NOT` phrase is added at the end to remove unrelated works using "clima
 ```py
 TS=
 (
-    ("improv*" OR "increase" OR "better" OR "enhanc*" OR "build*" OR "strengthen*" OR "raise" OR "raising"
+    ("improv*" OR "increase" OR "better" OR "enhanc*" OR "build" OR "building" OR "strengthen*" OR "raise" OR "raising"
     OR "develop" OR "developing" OR "create" OR "creation" OR "implement*" OR "integrat*" OR "adopt*"
     OR "invest" OR "investing" OR "fund$" OR "funding"
     OR "development assistance" OR "development aid" OR "development fund*" OR "foreign aid" OR "international aid" OR "cooperation fund*"

--- a/SDG13_query_topic_WoS.md
+++ b/SDG13_query_topic_WoS.md
@@ -210,6 +210,8 @@ Interpretation of what should be considered as contributing to raising "human an
 
 We include general terms about climate change mitigation/ adaption/ impact reduction/ early warning as well as the reduction of greenhouse gases (as a main method of climate change mitigation). In addition to generic terms for greenhouse gases, we use six main greenhouse gases (covered by the Kyoto Protocol; <a id="IPCC2014">[IPCC 2014](#f3)</a>), some of which are combined with *climate change* as these gases, when used alone with `reduc*`, find some chemical results (e.g. a reaction for methane reduction).
 
+A double `NOT` phrase is added at the end to remove unrelated works using "climate" in a metaphorical way (e.g. "motivational climate"), unrelated to climate change.
+
 ```py
 TS=
 (   

--- a/SDG13_query_topic_WoS.md
+++ b/SDG13_query_topic_WoS.md
@@ -197,7 +197,9 @@ TS=
 >
 >13.3.1 Extent to which (i) global citizenship education and (ii) education for sustainable development are mainstreamed in (a) national education policies; (b) curricula; (c) teacher education; and (d) student assessment
 
-This target is considered to cover research about education, awareness and capacity about climate change mitigation, adaptation, impact reduction and early warning.
+This target is considered to cover research about climate change mitigation, adaptation, impact reduction and early warning.
+
+In the first revision (v1.0.0), this target was originally considered to cover research about **capacity** for climate change mitigation, adaptation, impact reduction and early warning. We tried to limit to research about capacity by combining *capacity terms* (e.g. `education`, `infrastructure$`, `capacity`, `tools` etc.) with *climate mitigation/adapt/warning terms*. However, feedback and testing showed that this was a bit too restrictive. We lost a lot of relevant works about, for example, soil management to reduce emissions and capture carbon; adaptation of crop varieties to climate change; CO2 storage technologies. Therefore we have now dropped the terms around capacity, on the assumption that research itself generates capacity in the form of knowledge, tools, technologies and infrastructures. 
 
 This query consists of 1 phrase. The elements of the phrase are: *climate mit/adapt/warning*
 
@@ -206,9 +208,7 @@ Interpretation of what should be considered as contributing to raising "human an
 * Definition of "capacity development": "the process whereby people, organizations and society as a whole unleash, strengthen, create, adapt, and maintain capacity over time, in order to achieve development results" (<a id="UNDGcapacity">[United Nations Development Group 2017](#f2)</a>).
 * "Awareness raising and knowledge building about the expected impacts of a changing climate and the need to adapt are normally starting point of capacity building efforts". (On capacity building for adaptation; <a id="climateADAPT">[Climate-ADAPT 2019](#f6)</a>).
 
-In the first revision (v1.0.0), we tried to limit to research about capacity by combining *capacity terms* (e.g. `education`, `infrastructure$`, `capacity`, `tools` etc.)with *climate mitigation/adapt/warning terms*. However, feedback and testing showed that this was a bit too restrictive. We lost a lot of relevant works about, for example, soil management to reduce emissions and capture carbon; adaptation of crop varieties to climate change; CO2 storage technologies. Therefore we have now, in the topic approach, dropped the terms around capacity, on the assumption that research itself generates capacity in the form of knowledge, tools, technologies and infrastructures. 
-
-For the *climate* terms, we include general terms about climate change mitigation/ adaption/ impact reduction/ early warning as well as the reduction of greenhouse gases (as a main method of climate change mitigation). We use six main greenhouse gases (covered by the Kyoto Protocol) as search terms (<a id="IPCC2014">[IPCC 2014](#f3)</a>), some of which are combined with *climate* as these gases, when used alone with `reduc*`, find some chemical results (e.g. a reaction for methane reduction).
+We include general terms about climate change mitigation/ adaption/ impact reduction/ early warning as well as the reduction of greenhouse gases (as a main method of climate change mitigation). In addition to generic terms for greenhouse gases, we use six main greenhouse gases (covered by the Kyoto Protocol; <a id="IPCC2014">[IPCC 2014](#f3)</a>), some of which are combined with *climate change* as these gases, when used alone with `reduc*`, find some chemical results (e.g. a reaction for methane reduction).
 
 ```py
 TS=

--- a/SDG13_query_topic_WoS.md
+++ b/SDG13_query_topic_WoS.md
@@ -216,11 +216,11 @@ TS=
     (
       ("climate" 
       OR "climate change" OR "climate warming" OR "warming climate" OR "global warming" OR "climatic change$" 
-      OR "climate emergency" OR "climate smart"
+      OR "climate emergency" OR "climate smart" OR "climate crisis"
       OR "sea level rise" OR "rising sea level$"
       )
       NEAR/5  
-          ("action$" OR "mitigat*" OR "resilien*" OR "climate adapt*"
+          ("action$" OR "mitigat*" OR "resilien*" OR "climate adapt*" OR "adaptive capacity" OR "capacity to adapt"
           OR "early warning" OR "warning system$" OR "preparedness" OR "risk$" OR "vulnerab*"
           OR "awareness" OR "climate education" OR "climate sensitive education" OR "climate change education" OR "climate literacy"
           OR "solutions" OR "problems"
@@ -234,7 +234,7 @@ TS=
     OR
     (
       ("climate change" OR "climate warming" OR "warming climate" OR "global warming" OR "climatic change$" 
-      OR "climate emergency" OR "climate smart"
+      OR "climate emergency" OR "climate smart" OR "climate crisis"
       OR "sea level rise" OR "rising sea level$"
       )
       NEAR/5 ("sustainab*" OR "adapt*" OR "cope" OR "coping")
@@ -263,13 +263,13 @@ TS=
             OR "sulphur hexafluoride" OR "sulfur hexafluoride" OR "SF6"
             )
       )
-      AND ("climate change" OR "global warming" OR "climatic change$" OR "sea level rise" OR "rising sea level$")
+    AND ("climate change" OR "global warming" OR "climatic change$" OR "sea level rise" OR "rising sea level$" OR "climate emergency" OR "climate smart" OR "climate crisis")
     )  
 )
 NOT 
 TS=
   (
-    ("motivational climate" OR "organi$ational climate" OR "safety climate" OR "learning climate") 
+    ("motivational climate" OR "organi$ational climate" OR "safety climate" OR "learning climate" OR "education climate") 
     NOT("climate change" OR "climate crisis" OR "global warming" OR "climatic change$" OR "sea level rise" OR "rising sea level$")
   )
 ```

--- a/SDG13_query_topic_WoS.md
+++ b/SDG13_query_topic_WoS.md
@@ -199,54 +199,79 @@ TS=
 
 This target is considered to cover research about education, awareness and capacity about climate change mitigation, adaptation, impact reduction and early warning.
 
-This query consists of 1 phrase. The elements of the phrase are: *education/awareness/capacity + climate mit/adapt/warning*
+This query consists of 1 phrase. The elements of the phrase are: *climate mit/adapt/warning*
 
 Interpretation of what should be considered as contributing to raising "human and institutional capacity" is challenging - according to the UNDG definition, it concerns anything that would increase the ability of people and institutions to successfully manage the situation. We have interpreted this to include improvements in areas such as technology, infrastructure, research, skills, and knowledge, in addition to institutional structures, practices and resources. Allocation, awareness or understanding of responsibilities can also be important in capacity. Awareness is included explicitly in some definitions.
 * Definition of "capacity": "[...] the ability of people, organizations and society as a whole to manage their affairs successfully" (<a id="UNDGcapacity">[United Nations Development Group 2017](#f2)</a>).
 * Definition of "capacity development": "the process whereby people, organizations and society as a whole unleash, strengthen, create, adapt, and maintain capacity over time, in order to achieve development results" (<a id="UNDGcapacity">[United Nations Development Group 2017](#f2)</a>).
 * "Awareness raising and knowledge building about the expected impacts of a changing climate and the need to adapt are normally starting point of capacity building efforts". (On capacity building for adaptation; <a id="climateADAPT">[Climate-ADAPT 2019](#f6)</a>).
 
-For the *climate* terms, we include general terms about climate change mitigation/ adaption/ impact reduction/ early warning as well as the reduction of greenhouse gases (as a main method of climate change mitigation).
+In the first revision (v1.0.0), we tried to limit to research about capacity by combining *capacity terms* (e.g. `education`, `infrastructure$`, `capacity`, `tools` etc.)with *climate mitigation/adapt/warning terms*. However, feedback and testing showed that this was a bit too restrictive. We lost a lot of relevant works about, for example, soil management to reduce emissions and capture carbon; adaptation of crop varieties to climate change; CO2 storage technologies. Therefore we have now, in the topic approach, dropped the terms around capacity, on the assumption that research itself generates capacity in the form of knowledge, tools, technologies and infrastructures. 
+
+For the *climate* terms, we include general terms about climate change mitigation/ adaption/ impact reduction/ early warning as well as the reduction of greenhouse gases (as a main method of climate change mitigation). We use six main greenhouse gases (covered by the Kyoto Protocol) as search terms (<a id="IPCC2014">[IPCC 2014](#f3)</a>), some of which are combined with *climate* as these gases, when used alone with `reduc*`, find some chemical results (e.g. a reaction for methane reduction).
 
 ```py
 TS=
-(
-  ("capacity" OR "capabilit*"
-  OR "educat*" OR "curriculum" OR "curricula" OR "teacher training" OR "climate literacy"
-  OR "research" OR "knowledge" OR "skills" OR "tools" OR "competenc*" OR "expertise" OR "training"
-  OR "awareness" OR "responsibilit*"
-  OR "infrastructure$" OR "technolog*" OR "early warning system$"
-  OR "communication" OR "collaboration" OR "cooperation" OR "co operation" OR "social network$" OR "information network$"
-  OR "economic resources" OR "financial resources" OR "human resource$"
-  OR (("institutional" OR "administrative" OR "policy" OR "governance") NEAR/5 ("structure$" OR "values" OR "practices" OR "arrangement$" OR "resources"))
-  )  
-  NEAR/15      
-      (
-        (
-          ("climate" OR "global warming" OR "climatic change$" OR "sea level rise")
-          NEAR/5  
-              ("action$" OR "sustainab*" OR "mitigat*" OR "adapt*" OR "cope" OR "coping" OR "resilien*"
-              OR "early warning" OR "warning system$" OR "preparedness" OR "risk$" OR "vulnerab*"
-              OR "awareness" OR "climate education" OR "climate sensitive education" OR "climate change education" OR "climate literacy"
-              OR "solutions" OR "problems"
-              OR
-                (
-                  ("reduc*" OR "minimi*" OR "decreas*" OR "limit" OR "alleviat*")
-                  NEAR/2 ("impact$" OR "effect$" OR "consequence$")        
-                )
-              )
-        )
-        OR
-          (
-            ("reduc*" OR "minimi*" OR "limit" OR "limiting" OR "decreas*" OR "lower" OR "mitigat*"
-            OR "alleviat*" OR "tackl*" OR "combat*" OR "prevent*" OR "stop*" OR "avoid*"
-            )
-              NEAR/5
-                  ("GHG" OR "greenhouse gas" OR "greenhouse gases" OR "carbon footprint" OR "CO2 footprint" OR "carbon emission$" OR "CO2 emission$")
-          )   
+(   
+    (
+      ("climate" 
+      OR "climate change" OR "climate warming" OR "warming climate" OR "global warming" OR "climatic change$" 
+      OR "climate emergency" OR "climate smart"
+      OR "sea level rise" OR "rising sea level$"
       )
+      NEAR/5  
+          ("action$" OR "mitigat*" OR "resilien*" OR "climate adapt*"
+          OR "early warning" OR "warning system$" OR "preparedness" OR "risk$" OR "vulnerab*"
+          OR "awareness" OR "climate education" OR "climate sensitive education" OR "climate change education" OR "climate literacy"
+          OR "solutions" OR "problems"
+          OR
+            (
+              ("reduc*" OR "minimi*" OR "decreas*" OR "limit" OR "alleviat*")
+              NEAR/2 ("impact$" OR "effect$" OR "consequence$")        
+            )
+          )
+    )
+    OR
+    (
+      ("climate change" OR "climate warming" OR "warming climate" OR "global warming" OR "climatic change$" 
+      OR "climate emergency" OR "climate smart"
+      OR "sea level rise" OR "rising sea level$"
+      )
+      NEAR/5 ("sustainab*" OR "adapt*" OR "cope" OR "coping")
+    )
+    OR
+    (
+      ("reduc*" OR "minimi*" OR "limit" OR "limiting" OR "decreas*" OR "lower" OR "mitigat*"
+      OR "alleviat*" OR "tackl*" OR "combat*" OR "prevent*" OR "stop*" OR "avoid*"
+      OR "capture" OR "storage" OR "sequestration"
+      )
+      NEAR/5
+          ("GHG" OR "greenhouse gas" OR "greenhouse gases" OR "carbon footprint" OR "CO2 footprint" OR "carbon emission$" OR "CO2 emission$")
+    )
+    OR 
+    (
+      (
+        ("reduc*" OR "minimi*" OR "limit" OR "limiting" OR "decreas*" OR "lower" OR "mitigat*"
+        OR "alleviat*" OR "tackl*" OR "combat*" OR "prevent*" OR "stop*" OR "avoid*"
+        OR "capture" OR "storage" OR "sequestration"
+        )
+        NEAR/3
+            ("methane" OR "CH4" 
+            OR "nitrous oxide" OR "NOX" OR "N2O" 
+            OR "carbon dioxide" OR "CO2" 
+            OR "hydrofluorocarbons" OR "HFCs" OR "perfluorocarbons" OR "PFCs" 
+            OR "sulphur hexafluoride" OR "sulfur hexafluoride" OR "SF6"
+            )
+      )
+      AND ("climate change" OR "global warming" OR "climatic change$" OR "sea level rise" OR "rising sea level$")
+    )  
 )
-
+NOT 
+TS=
+  (
+    ("motivational climate" OR "organi$ational climate" OR "safety climate" OR "learning climate") 
+    NOT("climate change" OR "climate crisis" OR "global warming" OR "climatic change$" OR "sea level rise" OR "rising sea level$")
+  )
 ```
 
 ### Target 13.a								


### PR DESCRIPTION
## Target 13.3
### Major changes
- Added double not to remove irrelevant climate expressions (e.g. "learning climate", "motivational climate")
- Added all greenhouse gases used in an earlier target, and added terms for sequestration/capture/storage along with the existing terms for *reductions*
- Dropped *capacity* terms (see documentation in the string for reasoning) after feedback on missing relevant works. This leads to a large increase in number of results (ca. 4x).
### Minor changes:
- Added extra climate synonyms (rising sea level, climate emergency, climate smart, climate crisis)
- After dropping *capacity* terms, `("sustainab*" OR "adapt*" OR "cope" OR "coping")` were moved so that they are no longer combined with only "climate" (too general), but with *climate change* terms instead
- Action: Changed "build*" to "build" OR "building" to avoid buildings
