### PR TITLE
Edit SDG07 (WoS)

### DIFF
--- a/SDG07_query_action_WoS.md
+++ b/SDG07_query_action_WoS.md
@@ -265,7 +265,7 @@ TS=
 
 #### Phrase 6
 
-This phrase finds works about improving affordability and reliability of energy services. The general structure is *action + afford/stable + energy*. in the action terms, `reduce` is not truncated due to chemical reduction. In the energy terms, `energy` and `power` are combined with other terms to avoid results from other subject areas (biological energy, mechanical power). `microgrids` etc. are included as these are specific technologies used in areas which may not have access to a centralised power grid system.
+This phrase finds works about improving affordability and reliability of energy services. The general structure is *action + afford/stable + energy*. in the action terms, `reduce` is not truncated due to chemical reduction. In the energy terms, `energy` and `power` are combined with other terms to avoid results from other subject areas (biological energy, mechanical power). `microgrids` etc. are included as these are specific technologies used in areas which may not have access to a centralised power grid system. We considered including "insecur*" alongside "unstable", "unreliab*" etc. but decided not to as it added too much noise.
 
 ```py
 TS=

--- a/SDG07_query_action_WoS.md
+++ b/SDG07_query_action_WoS.md
@@ -10,7 +10,7 @@
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters, publication year = last 5 years):
+Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters, publication year = last 5 years): https://www.webofscience.com/wos/woscc/summary/2889314a-02f0-4be1-b77e-9f61555babbf-a8635838/relevance/1
 
 ## 2. General notes
 

--- a/SDG07_query_action_WoS.md
+++ b/SDG07_query_action_WoS.md
@@ -137,7 +137,7 @@ TS=
 
 #### Phrase 3
 
-The basic structure is *"dirty" fuels + action + households*. It is similar to phrase 1, but the negative side (e.g. phasing out). Within the WHO guidelines for indoor air quality (<a id="WHOair">[WHO, 2014, Executive summary and p.34-35](#f3)</a>), PM2.5 and carbon monoxide are identified in emissions targets, and unprocessed coal and kerosene should be avoided as fuels. Searching for coal + heating is challenging as lots of industrial results, hence the two parts of this phrase.
+The basic structure is *"dirty" fuels + action + households*. It is similar to phrase 1, but the negative side (e.g. phasing out). Within the WHO guidelines for indoor air quality (<a id="WHOair">[WHO, 2014, Executive summary and p.34-35](#f3)</a>), PM2.5 and carbon monoxide are identified in emissions targets, and unprocessed coal and kerosene should be avoided as fuels. Searching for coal + heating is challenging as lots of industrial results, hence the two parts of this phrase. "domestic use*" replaces "domestic" from phrase 1 to avoid research concerned with domestic in the sense locally produced / not imported (coal etc.).
 
 ```py
 TS=

--- a/SDG07_query_action_WoS.md
+++ b/SDG07_query_action_WoS.md
@@ -626,7 +626,7 @@ TS=
       )
   )
   NEAR/15
-      ("energy service$" OR "energy sector" OR "electrical infrastructure" OR "electricity supply" OR "power supply"
+      ("energy service$" OR "energy sector" OR "electrical infrastructure" OR "electricity supply" OR "power supply" OR "clean energy"
       OR (("energy" OR "electricity") NEAR/5 ("infrastructure" OR "technolog*" OR "off grid" OR "decentrali$ed" OR "cooperative$"))
       OR "community energy" OR "community renewable energy"
       OR "electrical grid$" OR "power grid$" OR "grid extension$" OR "microgrid$" OR "micro grid$" OR "minigrid$" OR "mini grid$" OR "smart grid$" OR "energy storage system$"

--- a/SDG07_query_action_WoS.md
+++ b/SDG07_query_action_WoS.md
@@ -1,7 +1,5 @@
 # Search query for SDG 7 - Affordable and clean energy, Bergen action-approach.
 
-**Current status**: This string is currently being edited after testing.
-
 **Contents**
 
 1. Full query in copy-pasteable format
@@ -12,7 +10,7 @@
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here:  (no filters; all years)
+Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters, publication year = last 5 years):
 
 ## 2. General notes
 
@@ -710,6 +708,10 @@ TS=
 * v1.0.0: Caroline S. Armitage (Oct 2021-Oct 2022), Marta Lorenz (Oct 2021-Apr 2022)
 
 * Internal review: Håkon Magne Bjerkan, Marta Lorenz (March 2022)
+
+* Testing v1.2.2: Project group; see documentation https://doi.org/10.5281/zenodo.8386611
+
+* v1.3.0: Eli Heldaas Seland (Aug-Sep 2023), minor review Håkon Magne Bjerkan.
 
 Specialist input: Shayan Shokrgozar (PhD candidate in energy transitions research, Jul 2022)
 

--- a/SDG07_query_action_WoS.md
+++ b/SDG07_query_action_WoS.md
@@ -1,6 +1,6 @@
 # Search query for SDG 7 - Affordable and clean energy, Bergen action-approach.
 
-**Current status**: This string is currently a finished version.
+**Current status**: This string is currently being edited after testing.
 
 **Contents**
 
@@ -12,7 +12,7 @@
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here: https://www.webofscience.com/wos/woscc/summary/a4886a8a-852f-459c-bdfe-9482c04d4ad7-57ba8ccd/relevance/1 (no filters; all years)
+Results of the full search in its current state can be viewed on Web of Science by clicking here:  (no filters; all years)
 
 ## 2. General notes
 

--- a/SDG07_query_action_WoS.md
+++ b/SDG07_query_action_WoS.md
@@ -431,7 +431,11 @@ TS=
     NEAR/15 ("phase out" OR "phasing out" OR "energy transition*" OR "energy strateg*" OR "energy management" OR "energy planning" OR "energy policy")
   )
 )
-NOT TS=("palm oil" OR "oil palm" OR "olive oil" OR "coconut oil" OR "vegetable oil" OR "eucalyptus oil" OR "cooking oil" OR "fish oil" OR "cylinder oil" OR "lubricat*" OR "lube oil" OR "engine oil")
+NOT TS=
+  ("palm oil" OR "oil palm" OR "olive oil" OR "coconut oil" OR "vegetable oil" OR "eucalyptus oil" OR "cooking oil" OR "fish oil" OR "liver oil" 
+  OR "nutrition" OR "cholesterol" OR "obes*" OR "human consum*"
+  OR "cylinder oil" OR "lubricat*" OR "lube oil" OR "engine oil"
+  )
 ```
 
 ### Target 7.3

--- a/SDG07_query_action_WoS.md
+++ b/SDG07_query_action_WoS.md
@@ -137,7 +137,7 @@ TS=
 
 #### Phrase 3
 
-The basic structure is *"dirty" fuels + action + households*. It is similar to phrase 1, but the negative side (e.g. phasing out). Within the WHO guidelines for indoor air quality (<a id="WHOair">[WHO, 2014, Executive summary and p.34-35](#f3)</a>), PM2.5 and carbon monoxide are identified in emissions targets, and unprocessed coal and kerosene should be avoided as fuels. Searching for coal + heating is challenging as lots of industrial results, hence the two parts of this phrase. "domestic use*" replaces "domestic" from phrase 1 to avoid research concerned with domestic in the sense locally produced / not imported (coal etc.).
+The basic structure is *"dirty" fuels + action + households*. It is similar to phrase 1, but the negative side (e.g. phasing out). Within the WHO guidelines for indoor air quality (<a id="WHOair">[WHO, 2014, Executive summary and p.34-35](#f3)</a>), PM2.5 and carbon monoxide are identified in emissions targets, and unprocessed coal and kerosene should be avoided as fuels. We considerered adding "paraffin" as term for fuels that should be avoided, but it proved little useful (few, rather old hits), and with potential for much noise to do with other uses of paraffin than in households. Searching for coal + heating is challenging as lots of industrial results, hence the two parts of this phrase. "domestic use*" replaces "domestic" from phrase 1 to avoid research concerned with domestic in the sense locally produced / not imported (coal etc.).
 
 ```py
 TS=

--- a/SDG07_query_action_WoS.md
+++ b/SDG07_query_action_WoS.md
@@ -154,7 +154,7 @@ TS=
         )
   )    
   NEAR/15 ("household$" OR "home$" OR "house" OR "houses" OR "housing"
-      OR "residential" OR "dwelling$" OR "domestic use*" OR "slum$" OR "village$" OR "women"
+      OR "residential" OR "dwelling$" OR "domestic use*" OR "slum" OR "slums" 
       OR "residential heating" OR "central heating" OR "winter heating" OR "cooking" OR "stove$" OR "lighting" OR "lamps")      
 )
 OR
@@ -172,7 +172,7 @@ TS=
   )    
   NEAR/15
       ("household$" OR "home$" OR "house" OR "houses" OR "housing"
-      OR "residential" OR "dwelling$" OR "domestic use*" OR "slum$" OR "village$" OR "women"
+      OR "residential" OR "dwelling$" OR "domestic use*" OR "slum" OR "slums" 
       OR "heating" OR "cooking" OR "stove$" OR "lighting" OR "lamps"
       )      
 )

--- a/SDG07_query_action_WoS.md
+++ b/SDG07_query_action_WoS.md
@@ -453,7 +453,7 @@ TS=
     NEAR/15 ("phase out" OR "phasing out" OR "energy transition*" OR "energy strateg*" OR "energy management" OR "energy planning" OR "energy policy")
   )
 )
-NOT TS=("palm oil" OR "olive oil" OR "coconut oil" OR "vegetable oil" OR "cooking oil" OR "fish oil" OR "cylinder oil" OR "lubricat*" OR "lube oil" OR "engine oil")
+NOT TS=("palm oil" OR "oil palm" OR "olive oil" OR "coconut oil" OR "vegetable oil" OR "eucalyptus oil" OR "cooking oil" OR "fish oil" OR "cylinder oil" OR "lubricat*" OR "lube oil" OR "engine oil")
 ```
 
 ### Target 7.3

--- a/SDG07_query_action_WoS.md
+++ b/SDG07_query_action_WoS.md
@@ -10,7 +10,7 @@
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters, publication year = last 5 years): https://www.webofscience.com/wos/woscc/summary/2889314a-02f0-4be1-b77e-9f61555babbf-a8635838/relevance/1
+Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters, publication year = last 5 years): https://www.webofscience.com/wos/woscc/summary/3b375f0a-e953-4728-a2e8-ca3f66d5d8e3-b77748c4/relevance/1
 
 ## 2. General notes
 
@@ -715,7 +715,7 @@ TS=
 
 * Testing v1.2.2: Project group; see documentation https://doi.org/10.5281/zenodo.8386611
 
-* v1.3.0: Eli Heldaas Seland (Aug-Sep 2023), minor review Håkon Magne Bjerkan.
+* v2.0.0: Eli Heldaas Seland (Aug-Sep 2023), minor review Håkon Magne Bjerkan.
 
 Specialist input: Shayan Shokrgozar (PhD candidate in energy transitions research, Jul 2022)
 

--- a/SDG07_query_action_WoS.md
+++ b/SDG07_query_action_WoS.md
@@ -273,7 +273,7 @@ TS=
   (
     (
       ("improv*" OR "increas*" OR "ensur*" OR "implement*")
-      NEAR/5 ("stable" OR "stability" OR "reliab*" OR "resilien*" OR "afford*" OR "inexpensive" OR "low cost" OR "cheap")  
+      NEAR/5 ("stable" OR "stability" OR "secur*" OR "reliab*" OR "resilien*" OR "afford*" OR "inexpensive" OR "low cost" OR "cheap")  
     )
     OR
     (

--- a/SDG07_query_action_WoS.md
+++ b/SDG07_query_action_WoS.md
@@ -593,12 +593,12 @@ TS=
         )
   )
   NEAR/15
-      ("cleantech" OR "energy research" OR "energy efficiency research" OR "energy transition$" OR "energy technolog*"
+      ("energy research" OR "energy efficiency research" OR "energy transition$" OR "energy technolog*"
       OR
         (
           ("technolog*" OR "innovation$" OR "R&D")
           NEAR/3
-              ("clean" OR "cleaner" OR "green" OR "greener"
+              ("clean* energy" OR "green* energy"
               OR "decarboni*" OR "low carbon" OR "energy efficien*"  
               OR "renewable$" OR "solar" OR "wind" OR "geothermal" OR "hydroelectric" OR "hydro electric" OR "hydropower" OR "marine energy" OR "tidal energy" OR "wave energy"
               )

--- a/SDG07_query_action_WoS.md
+++ b/SDG07_query_action_WoS.md
@@ -411,7 +411,7 @@ TS=
 
 #### Phrase 3
 
-This phrase covers reduction in fossil fuels. The general structure is *fossil fuels + action OR promotional action + use/reliance*. Some phrases with `oil` are exluded with NOT to avoid irrelevant hits about uses of e.g. palm oil and fish oil.
+This phrase covers reduction in fossil fuels. The general structure is *fossil fuels + reliance/reduced use OR fossil fuels + phrase out/energy strategy*. Some phrases with `oil` are exluded with NOT to avoid irrelevant hits about uses of e.g. palm oil and fish oil. `petroleum` is only used in the second combination as if used in the first there are many results about it's use as a material, rather than in an energy context.
 
 ```py
 (
@@ -427,7 +427,7 @@ TS=
 OR 
 TS=
   (
-    ("fossil fuel$" OR "coal" OR "oil" OR "natural gas" OR "grey hydrogen" OR "conventional energy")
+    ("fossil fuel$" OR "coal" OR "oil" OR "natural gas" OR "grey hydrogen" OR "conventional energy" OR "petroleum")
     NEAR/15 ("phase out" OR "phasing out" OR "energy transition*" OR "energy strateg*" OR "energy management" OR "energy planning" OR "energy policy")
   )
 )

--- a/SDG07_query_action_WoS.md
+++ b/SDG07_query_action_WoS.md
@@ -382,7 +382,7 @@ TS=
               )    
         )
       OR "geothermal heat pump$" OR "ground source heat pump$"
-      OR "solar cell$" OR "solar-cell$" OR "solar panel$" OR "solar-panel$" OR "solar power*" OR "solar array" OR "solar PV" OR "solar photovoltaic$"
+      OR "solar cell$" OR "solar-cell$" OR "solar panel$" OR "solar-panel$" OR "solar power*" OR "solar array" OR "solar PV" OR "photovoltaic$"
       OR "solar energy collector$" OR "solar farm$" OR "solar plant$" OR "solar park$"
       OR "solar district heating" OR "solar district cooling" OR "solar air heating system$" OR "solar space heating system$"
       OR ("solar thermal" NEAR/3 ("power" OR "technolog*" OR "collector$" OR "district"))

--- a/SDG07_query_action_WoS.md
+++ b/SDG07_query_action_WoS.md
@@ -160,7 +160,7 @@ TS=
 OR
 TS=
 (
-  ("coal"
+  ("kerosene" OR "solid fuel$"
   NEAR/5
       ("transition*" OR "substitut*" OR "switch" OR "coal to electricity" OR "intervention$" OR "initiative$"
       OR "encourag*" OR "incentive$" OR "investing" OR "invest"

--- a/SDG07_query_action_WoS.md
+++ b/SDG07_query_action_WoS.md
@@ -462,7 +462,7 @@ TS=
       )
   )
   AND
-      ("energy consum*" OR "sustainab*" OR "energy efficiency"
+      ("energy consum*" OR "energy-saving" OR "sustainab*" OR "energy efficiency"
       OR "GDP" OR "economic" OR "economy" OR "economies"
       OR "industry" OR "industrial" OR "manufacturing"
       OR ("emission$" NEAR/5 ("carbon" OR "co2"))

--- a/SDG07_query_action_WoS.md
+++ b/SDG07_query_action_WoS.md
@@ -311,6 +311,16 @@ TS=
 
 This target is interpreted to cover research about increasing the use of renewable energy. This includes research about the transition of energy systems to renewables (e.g. research discussing transitions, access, incentives, policies), research about increasing the use/share, research about bringing of technology into use (e.g. commercialisation, scaling up, investment), and research about reducing reliance on fossil fuels. Basic research on renewable energy technology is not included, unless it also discusses increasing the global share (or mechanisms to increase it).
 
+This target is interpreted to cover research about increasing use and uptake of renewable energy (including sustainable batteries). We consider this to include research about:
+
+-	the transition of energy systems to renewables (e.g. research discussing energy transitions, improving access/removing barriers to renewables, incentives such as certificates, and policies)
+-	increasing the use/share of renewables (e.g. increasing adoption and share in the energy sector)
+-	mechanisms that incentivise renewable energy technology (e.g. commercialisation, scaling-up, increasing investment)
+-	reducing reliance on and consumption of fossil fuels
+
+Research on renewable energy technology alone, without a use/uptake element, is not included.
+
+
 This query consists of 3 phrases.
 
 #### Phrase 1
@@ -425,6 +435,25 @@ TS=
     OR "global energy" OR "global electricity" OR "energy mix"
     )
 )   
+
+(
+TS=
+  (
+    ("fossil fuel$" OR "coal" OR "oil" OR "natural gas" OR "grey hydrogen" OR "conventional energy")
+    NEAR/5
+      (
+        ("reduc*" OR "decreas*" OR "improv*" OR "support" OR "encourag*" OR "intervention$" OR "policy" OR "policies" OR "legislation" OR "incentiv*")
+        NEAR/5 ("use" OR "usage" OR "relian*" OR "consumption" OR "transition$" OR "substitut*" OR "primary source$")
+      )
+  )
+OR 
+TS=
+  (
+    ("fossil fuel$" OR "coal" OR "oil" OR "natural gas" OR "grey hydrogen" OR "conventional energy")
+    NEAR/15 ("phase out" OR "phasing out" OR "energy transition*" OR "energy strateg*" OR "energy management" OR "energy planning" OR "energy policy")
+  )
+)
+NOT TS=("palm oil" OR "olive oil" OR "coconut oil" OR "vegetable oil" OR "cooking oil" OR "fish oil" OR "cylinder oil" OR "lubricat*" OR "lube oil" OR "engine oil")
 ```
 
 ### Target 7.3

--- a/SDG07_query_action_WoS.md
+++ b/SDG07_query_action_WoS.md
@@ -309,14 +309,13 @@ TS=
 >
 > 7.2.1 Renewable energy share in the total final energy consumption
 
-This target is interpreted to cover research about increasing the use of renewable energy. This includes research about the transition of energy systems to renewables (e.g. research discussing transitions, access, incentives, policies), research about increasing the use/share, research about bringing of technology into use (e.g. commercialisation, scaling up, investment), and research about reducing reliance on fossil fuels. Basic research on renewable energy technology is not included, unless it also discusses increasing the global share (or mechanisms to increase it).
 
 This target is interpreted to cover research about increasing use and uptake of renewable energy (including sustainable batteries). We consider this to include research about:
 
 -	the transition of energy systems to renewables (e.g. research discussing energy transitions, improving access/removing barriers to renewables, incentives such as certificates, and policies)
 -	increasing the use/share of renewables (e.g. increasing adoption and share in the energy sector)
 -	mechanisms that incentivise renewable energy technology (e.g. commercialisation, scaling-up, increasing investment)
--	reducing reliance on and consumption of fossil fuels
+-	reducing reliance on and use of fossil fuels
 
 Research on renewable energy technology alone, without a use/uptake element, is not included.
 
@@ -325,7 +324,7 @@ This query consists of 3 phrases.
 
 #### Phrase 1
 
-This phrase covers the general terms of transitioning and transforming to renewable energy. The elements of the phrase are: *renwables + energy transitions/transformations/substitutions*. "energy transition" is not used alone as this does not necessarily mean renewables (e.g. one can talk about historical energy transitions from wood to steam). While there are no typical action terms, the term "energy transition" itself relates to the shift, so we assume works talking about this are related to the change in the share of renewables. 
+This phrase covers the general terms of transitioning and transforming to renewable energy. The elements of the phrase are: *renewables + energy transitions/transformations/substitutions*. "energy transition" is not used alone as this does not necessarily mean renewables (e.g. one can talk about historical energy transitions from wood to steam). While there are no typical action terms, the term "energy transition" itself relates to the shift, so we assume works talking about this are related to the change in the share of renewables. 
 
 ```py
 TS=
@@ -414,28 +413,9 @@ TS=
 
 #### Phrase 3
 
-This phrase covers reduction in fossil fuels. The general structure is *action + fossil fuels + reliance/energy mix*. `consumption` is used in phrases as in combination with "oil" it causes issues (e.g. fish oil).
+This phrase covers reduction in fossil fuels. The general structure is *fossil fuels + action OR promotional action + use/reliance*. Some phrases with `oil` are exluded with NOT to avoid irrelevant hits about uses of e.g. palm oil and fish oil.
 
 ```py
-TS=
-(
-  (
-    ("reduce" OR "decreas*" OR "phase out" OR "phasing out"
-    OR "improv*" OR "incentiv*" OR "support" OR "encourag*"
-    OR "transition*" OR "substitut*" OR "intervention$"
-    OR "policy" OR "policies" OR "legislation" OR "energy strateg*" OR "energy management" OR "energy planning"
-    )
-    NEAR/5
-        ("fossil fuel$" OR "coal" OR "oil" OR "natural gas" OR "grey hydrogen" OR "conventional energy")
-  )
-  NEAR/15
-    ("relian*" OR "primary use" OR "primary usage" OR "primary source$"
-    OR "coal consumption" OR "fossil fuel consumption" OR "consumption of fossil fuel$"
-    OR "energy service$" OR "energy sector" OR "energy supply" OR "energy supplies"
-    OR "global energy" OR "global electricity" OR "energy mix"
-    )
-)   
-
 (
 TS=
   (

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -362,7 +362,7 @@ TS=
 (
   ("energy intensity")
   AND
-      ("energy consum*" OR "sustainab*" OR "energy efficiency"
+      ("energy consum*" OR "energy-saving" OR "sustainab*" OR "energy efficiency"
       OR "GDP" OR "economic" OR "economy" OR "economies"
       OR "industry" OR "industrial" OR "manufacturing"
       OR ("emission$" NEAR/5 ("carbon" OR "co2"))

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -520,7 +520,7 @@ TS=
   OR "green bond$" OR "climate bond$"  
   )
   NEAR/15
-      ("energy service$" OR "energy sector" OR "electrical infrastructure" OR "electricity supply" OR "power supply"
+      ("energy service$" OR "energy sector" OR "electrical infrastructure" OR "electricity supply" OR "power supply" OR "clean energy"
       OR (("energy" OR "electricity") NEAR/5 ("infrastructure" OR "technolog*" OR "off grid" OR "decentrali$ed" OR "cooperative$"))
       OR "community energy" OR "community renewable energy"
       OR "electrical grid$" OR "power grid$" OR "grid extension$" OR "microgrid$" OR "micro grid$" OR "minigrid$" OR "mini grid$" OR "smart grid$" OR "energy storage system$"

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -334,6 +334,7 @@ TS=
     OR "coal consumption" OR "fossil fuel consumption" OR "consumption of fossil fuel$"
     OR "energy service$" OR "energy sector" OR "energy supply" OR "energy supplies"
     OR "global energy" OR "global electricity" OR "energy mix"
+    OR "phase out" OR "phasing out" OR "transition*" 
     )
 )   
 ```

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -1,7 +1,5 @@
 # Search query for SDG 7 - Affordable and clean energy, Bergen topic-approach.
 
-**Current status**: This string is currently being edited after testing.
-
 **Contents**
 
 1. Full query in copy-pasteable format
@@ -646,6 +644,10 @@ NOT
 * v1.0.0: Caroline S. Armitage (Oct 2021-Oct 2022), Marta Lorenz (Oct 2021-Apr 2022)
 
 * Internal review: Håkon Magne Bjerkan, Marta Lorenz (March 2022), Håkon Magne Bjerkan (minor review Oct 2022)
+
+* Testing v1.2.2: Project group; see documentation https://doi.org/10.5281/zenodo.8386611
+
+* v1.3.0: Eli Heldaas Seland (Aug-Sep 2023), minor review Håkon Magne Bjerkan.
 
 Specialist input: Shayan Shokrgozar (PhD candidate in energy transitions research, Jul 2022)
 

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -316,7 +316,7 @@ TS=
 
 #### Phrase 3
 
-This phrase covers reliance on and reduction in use of fossil fuels. Many of the same action terms as in the action approached are used here. The general structure is *fossil fuels + reliance OR promotional action / actions*. Some phrases with `oil` are exluded with NOT to avoid irrelevant hits about uses of e.g. palm oil and fish oil.
+This phrase covers reliance on and reduction in use of fossil fuels. The general structure is *fossil fuels + reliance/reduced use OR fossil fuels + phrase out/energy strategy*. This tructure is similar to the action approach, but extra *energy strategy* terms are included here. Some phrases with `oil` are exluded with NOT to avoid irrelevant hits about uses of e.g. palm oil and fish oil. `petroleum` is only used in the second combination as if used in the first there are many results about it's use as a material, rather than in an energy context.
 
 ```py
 (
@@ -336,7 +336,7 @@ This phrase covers reliance on and reduction in use of fossil fuels. Many of the
   OR 
   TS=
   (
-    ("fossil fuel$" OR "coal" OR "oil" OR "natural gas" OR "grey hydrogen" OR "conventional energy")
+    ("fossil fuel$" OR "coal" OR "oil" OR "natural gas" OR "grey hydrogen" OR "conventional energy" OR "petroleum")
     NEAR/15
         ("phase out" OR "phasing out" OR "energy transition*"
         OR "energy strateg*" OR "energy management" OR "energy planning" OR "energy policy" 

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -229,6 +229,18 @@ One could interpret this target in two ways according to the topic approach:
 2. This target is interpreted to cover research about renewable energy. 
 These two different interpretations make a large difference to the number of results, given (2) will find a large number of technical publications about renewable energy technology (gives ca. 3.5x the number of results as interpretation (1)). For the moment, we have decided to use interpretation (1). This means that the strings attempt to find publications focusing on renewable energy use and uptake, including works that talk about the share, transitions, policies, commercialisation, scaling up, and investment in renewable energy, and research about reliance on and consumption of fossil fuels.
 
+
+This target is interpreted to cover research about the use and uptake of renewable energy (including sustainable batteries). We consider this to include research about:
+
+-	the transition of energy systems to renewables (e.g. research discussing energy transitions, access/barriers to renewables, incentives such as certificates, and policies)
+-	the use/share of renewables (e.g. adoption, works about share in the energy sector)
+-	mechanisms that incentivise renewable energy technology (e.g. commercialisation, scaling-up, investment)
+-	reliance on and consumption of fossil fuels
+
+Research on renewable energy technology alone, without a use/uptake element, is not included.
+
+
+
 This query consists of 3 phrases.
 
 #### Phrase 1
@@ -333,10 +345,39 @@ TS=
     ("relian*" OR "primary use" OR "primary usage" OR "primary source$"
     OR "coal consumption" OR "fossil fuel consumption" OR "consumption of fossil fuel$"
     OR "energy service$" OR "energy sector" OR "energy supply" OR "energy supplies"
-    OR "global energy" OR "global electricity" OR "energy mix"
+    OR "global share" OR "global electricity" OR "energy mix"
     OR "phase out" OR "phasing out" OR "transition*" 
     )
 )   
+
+(
+  TS=
+  (
+    ("fossil fuel$" OR "coal" OR "oil" OR "natural gas" OR "grey hydrogen" OR "conventional energy")
+    NEAR/5
+      ("relian*" OR "consumption" OR "transition$" OR "substitut*"
+      OR "policy" OR "policies" OR "legislation" OR "incentiv*" 
+      OR
+        (
+          ("reduc*" OR "decreas*" OR "improv*" OR "support" OR "encourag*" OR "intervention$")
+          NEAR/5 ("use" OR "usage")
+        )
+      )
+  )
+  OR 
+  TS=
+  (
+    ("fossil fuel$" OR "coal" OR "oil" OR "natural gas" OR "grey hydrogen" OR "conventional energy")
+    NEAR/15
+        ("phase out" OR "phasing out" OR "energy transition*"
+        OR "energy strateg*" OR "energy management" OR "energy planning" OR "energy policy" 
+        OR "energy service$" OR "energy sector" OR "energy supply" OR "energy supplies" OR "energy generation"
+        OR "global share" OR "global electricity" OR "energy mix" 
+        OR "coal consumption" OR "fossil fuel consumption" OR "consumption of fossil fuel$" OR "primary source$" 
+        )
+  )
+)
+NOT TS=("palm oil" OR "olive oil" OR "coconut oil" OR "vegetable oil" OR "cooking oil" OR "fish oil" OR "cylinder oil" OR "lubricat*" OR "lube oil" OR "engine oil")
 ```
 
 ### Target 7.3

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -191,7 +191,7 @@ TS=
 
 #### Phrase 6
 
-This phrase finds works about affordability and reliability of energy services. The elements of the phrase are: *afford/stable + energy*. In the energy terms, `energy` and `power` are combined with other terms to avoid results from other subject areas (biological energy, mechanical power). `microgrids` etc. are included as these are specific technologies used in areas which may not have access to a centralised power grid system.
+This phrase finds works about affordability and reliability of energy services. The elements of the phrase are: *afford/stable + energy*. In the energy terms, `energy` and `power` are combined with other terms to avoid results from other subject areas (biological energy, mechanical power). `microgrids` etc. are included as these are specific technologies used in areas which may not have access to a centralised power grid system. We considered including "insecur*" alongside "unstable", "unreliab*" etc. but decided not to as it added too much noise.
 
 ```py
 TS=

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -96,7 +96,7 @@ TS=
 
 #### Phrase 3
 
-The elements of the phrase are: *"dirty" fuels + households*. It is similar to phrase 1, but the negative side (e.g. phasing out). Within the WHO guidelines for indoor air quality (<a id="WHOair">[WHO, 2014, Executive summary and p.34-35](#f3)</a>), PM2.5 and carbon monoxide are identified in emissions targets, and unprocessed coal and kerosene should be avoided as fuels. Searching for coal + heating is challenging as lots of industrial results, hence the two parts of this phrase. The household terms are slightly edited compared to the action string to reduce noise (`slum OR slums`, and removed `village$`). "domestic use*" replaces "domestic" from phrase 1 to avoid research concerned with domestic in the sense locally produced / not imported (coal etc.).
+The elements of the phrase are: *"dirty" fuels + households*. It is similar to phrase 1, but the negative side (e.g. phasing out). Within the WHO guidelines for indoor air quality (<a id="WHOair">[WHO, 2014, Executive summary and p.34-35](#f3)</a>), PM2.5 and carbon monoxide are identified in emissions targets, and unprocessed coal and kerosene should be avoided as fuels. Searching for coal + heating is challenging as lots of industrial results, hence the two parts of this phrase. "domestic use*" replaces "domestic" from phrase 1 to avoid research concerned with domestic in the sense locally produced / not imported (coal etc.).
 
 ```py
 TS=

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -251,7 +251,7 @@ TS=
 
 #### Phrase 2
 
-This phrase covers terms renewable energy. The elements of the phrase are: *use/share/adoption/investing/barriers/promotional actions + renewable energy*.
+This phrase covers terms for renewable energy. The elements of the phrase are: *use/share/adoption/investing/barriers/promotional actions + renewable energy*.
 
 In the *renewable energy terms*, `biomass`, `wind` and `solar` are generally combined with other terms to prevent results from other subject areas (e.g. astronomy) - these have been narrowed slightly in the topic approach compared to the action approach (particularly biomass was causing issues). Energy storage and smart grids to deal with fluctuations in supply can be considered part of renewable energy transition (<a id="HLPF2018">[UN High level political forum on Sustainable Development, 2018](#f3)</a>). We include the term `green` energy/power etc. - a potential problem is that some may use this term very widely to include non-renewables (see discussion under "General Notes"). However a test demonstrated that this is not a large issue - of over 1200 results referring to green energy/power/electricity, only around 35 referred to "natural gas" and 30 to "nuclear".
 

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -224,18 +224,12 @@ TS=
 >
 > 7.2.1 Renewable energy share in the total final energy consumption
 
-One could interpret this target in two ways according to the topic approach:
-1. This target is interpreted to cover research about the use and uptake of renewable energy, or
-2. This target is interpreted to cover research about renewable energy. 
-These two different interpretations make a large difference to the number of results, given (2) will find a large number of technical publications about renewable energy technology (gives ca. 3.5x the number of results as interpretation (1)). For the moment, we have decided to use interpretation (1). This means that the strings attempt to find publications focusing on renewable energy use and uptake, including works that talk about the share, transitions, policies, commercialisation, scaling up, and investment in renewable energy, and research about reliance on and consumption of fossil fuels.
-
-
 This target is interpreted to cover research about the use and uptake of renewable energy (including sustainable batteries). We consider this to include research about:
 
 -	the transition of energy systems to renewables (e.g. research discussing energy transitions, access/barriers to renewables, incentives such as certificates, and policies)
 -	the use/share of renewables (e.g. adoption, works about share in the energy sector)
 -	mechanisms that incentivise renewable energy technology (e.g. commercialisation, scaling-up, investment)
--	reliance on and consumption of fossil fuels
+-	reliance on and use of fossil fuels
 
 Research on renewable energy technology alone, without a use/uptake element, is not included.
 
@@ -245,7 +239,7 @@ This query consists of 3 phrases.
 
 #### Phrase 1
 
-This phrase covers the general terms of transitioning and transforming to renewable energy. The elements of the phrase are: *renwables + energy transitions/transformations/substitutions*. "energy transition" is not used alone as this does not necessarily mean renewables (e.g. one can talk about historical energy transitions from wood to steam). Compared to the action approach, a wider distance is used between elements.
+This phrase covers the general terms of transitioning and transforming to renewable energy. The elements of the phrase are: *renewables + energy transitions/transformations/substitutions*. "energy transition" is not used alone as this does not necessarily mean renewables (e.g. one can talk about historical energy transitions from wood to steam). Compared to the action approach, a wider distance is used between elements.
 
 ```py
 TS=
@@ -324,32 +318,9 @@ TS=
 
 #### Phrase 3
 
-This phrase covers reliance on and consumption of fossil fuels. The elements of the phrase are: *fossil fuels + reliance/energy mix*. Action terms are retained for "oil" because it is used to generally (e.g. consuption of fish oil, reliance of technology for oil drilling etc.)
+This phrase covers reliance on and reduction in use of fossil fuels. Many of the same action terms as in the action approached are used here. The general structure is *fossil fuels + reliance OR promotional action / actions*. Some phrases with `oil` are exluded with NOT to avoid irrelevant hits about uses of e.g. palm oil and fish oil.
 
 ```py
-TS=
-(
-  ("fossil fuel$" OR "coal" OR "natural gas" OR "grey hydrogen" OR "conventional energy"
-  OR
-    (
-      ("reduce" OR "decreas*" OR "phase out" OR "phasing out"
-      OR "improv*" OR "incentiv*" OR "support" OR "encourag*"
-      OR "transition*" OR "substitut*" OR "intervention$"
-      OR "policy" OR "policies" OR "legislation" OR "energy strateg*" OR "energy management" OR "energy planning"
-      )
-      NEAR/5
-          ("oil")
-    )
-  )
-  NEAR/15
-    ("relian*" OR "primary use" OR "primary usage" OR "primary source$"
-    OR "coal consumption" OR "fossil fuel consumption" OR "consumption of fossil fuel$"
-    OR "energy service$" OR "energy sector" OR "energy supply" OR "energy supplies"
-    OR "global share" OR "global electricity" OR "energy mix"
-    OR "phase out" OR "phasing out" OR "transition*" 
-    )
-)   
-
 (
   TS=
   (

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -377,7 +377,7 @@ TS=
         )
   )
 )
-NOT TS=("palm oil" OR "olive oil" OR "coconut oil" OR "vegetable oil" OR "cooking oil" OR "fish oil" OR "cylinder oil" OR "lubricat*" OR "lube oil" OR "engine oil")
+NOT TS=("palm oil" OR "oil palm" OR "olive oil" OR "coconut oil" OR "vegetable oil" OR "eucalyptus oil" OR "cooking oil" OR "fish oil" OR "cylinder oil" OR "lubricat*" OR "lube oil" OR "engine oil")
 ```
 
 ### Target 7.3

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -96,7 +96,7 @@ TS=
 
 #### Phrase 3
 
-The elements of the phrase are: *"dirty" fuels + households*. It is similar to phrase 1, but the negative side (e.g. phasing out). Within the WHO guidelines for indoor air quality (<a id="WHOair">[WHO, 2014, Executive summary and p.34-35](#f3)</a>), PM2.5 and carbon monoxide are identified in emissions targets, and unprocessed coal and kerosene should be avoided as fuels. Searching for coal + heating is challenging as lots of industrial results, hence the two parts of this phrase. The household terms are slightly edited compared to the action string to reduce noise (`slum OR slums`, and removed `village$`).
+The elements of the phrase are: *"dirty" fuels + households*. It is similar to phrase 1, but the negative side (e.g. phasing out). Within the WHO guidelines for indoor air quality (<a id="WHOair">[WHO, 2014, Executive summary and p.34-35](#f3)</a>), PM2.5 and carbon monoxide are identified in emissions targets, and unprocessed coal and kerosene should be avoided as fuels. Searching for coal + heating is challenging as lots of industrial results, hence the two parts of this phrase. The household terms are slightly edited compared to the action string to reduce noise (`slum OR slums`, and removed `village$`). "domestic use*" replaces "domestic" from phrase 1 to avoid research concerned with domestic in the sense locally produced / not imported (coal etc.).
 
 ```py
 TS=

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -346,7 +346,11 @@ This phrase covers reliance on and reduction in use of fossil fuels. Many of the
         )
   )
 )
-NOT TS=("palm oil" OR "oil palm" OR "olive oil" OR "coconut oil" OR "vegetable oil" OR "eucalyptus oil" OR "cooking oil" OR "fish oil" OR "cylinder oil" OR "lubricat*" OR "lube oil" OR "engine oil")
+NOT TS=
+  ("palm oil" OR "oil palm" OR "olive oil" OR "coconut oil" OR "vegetable oil" OR "eucalyptus oil" OR "cooking oil" OR "fish oil" OR "liver oil" 
+  OR "nutrition" OR "cholesterol" OR "obes*" OR "human consum*"
+  OR "cylinder oil" OR "lubricat*" OR "lube oil" OR "engine oil"
+  )
 ```
 
 ### Target 7.3

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -96,7 +96,7 @@ TS=
 
 #### Phrase 3
 
-The elements of the phrase are: *"dirty" fuels + households*. It is similar to phrase 1, but the negative side (e.g. phasing out). Within the WHO guidelines for indoor air quality (<a id="WHOair">[WHO, 2014, Executive summary and p.34-35](#f3)</a>), PM2.5 and carbon monoxide are identified in emissions targets, and unprocessed coal and kerosene should be avoided as fuels. Searching for coal + heating is challenging as lots of industrial results, hence the two parts of this phrase. "domestic use*" replaces "domestic" from phrase 1 to avoid research concerned with domestic in the sense locally produced / not imported (coal etc.).
+The elements of the phrase are: *"dirty" fuels + households*. It is similar to phrase 1, but the negative side (e.g. phasing out). Within the WHO guidelines for indoor air quality (<a id="WHOair">[WHO, 2014, Executive summary and p.34-35](#f3)</a>), PM2.5 and carbon monoxide are identified in emissions targets, and unprocessed coal and kerosene should be avoided as fuels. We considerered adding "paraffin" as term for fuels that should be avoided, but it proved little useful (few, rather old hits), and with potential for much noise to do with other uses of paraffin than in households. Searching for coal + heating is challenging as lots of industrial results, hence the two parts of this phrase. "domestic use*" replaces "domestic" from phrase 1 to avoid research concerned with domestic in the sense locally produced / not imported (coal etc.).
 
 ```py
 TS=

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -10,7 +10,7 @@
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here:  (no filters; all years)
+Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters; publication year = last 5 years): https://www.webofscience.com/wos/woscc/summary/48102699-d0f9-4682-bd31-e7c58c425164-a8639e82/relevance/1
 
 ## 2. General notes
 

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -287,7 +287,7 @@ TS=
               )    
         )
       OR "geothermal heat pump$" OR "ground source heat pump$"
-      OR "solar cell$" OR "solar-cell$" OR "solar panel$" OR "solar-panel$" OR "solar power*" OR "solar array" OR "solar PV" OR "solar photovoltaic$"
+      OR "solar cell$" OR "solar-cell$" OR "solar panel$" OR "solar-panel$" OR "solar power*" OR "solar array" OR "solar PV" OR "photovoltaic$"
       OR "solar energy collector$" OR "solar farm$" OR "solar plant$" OR "solar park$"
       OR "solar district heating" OR "solar district cooling" OR "solar air heating system$" OR "solar space heating system$"
       OR ("solar thermal" NEAR/3 ("power" OR "technolog*" OR "collector$" OR "district"))

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -112,7 +112,7 @@ TS=
 OR
 TS=
 (
-  ("coal")    
+  ("kerosene" OR "solid fuel$")    
   NEAR/15
       ("household$" OR "homes" OR "house" OR "houses" OR "housing"
       OR "residential" OR "dwelling$" OR "domestic use*" OR "slum" OR "slums" 

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -498,12 +498,12 @@ TS=
   OR "green bond$" OR "climate bond$"
   )
   NEAR/15
-      ("cleantech" OR "energy research" OR "energy efficiency research" OR "energy transition$" OR "energy technolog*"
+      ("energy research" OR "energy efficiency research" OR "energy transition$" OR "energy technolog*"
       OR
         (
           ("technolog*" OR "innovation$" OR "R&D")
           NEAR/3
-              ("clean" OR "cleaner" OR "green" OR "greener"
+              ("clean* energy" OR "green* energy"
               OR "decarboni*" OR "low carbon" OR "energy efficien*"  
               OR "renewable$" OR "solar" OR "wind" OR "geothermal" OR "hydroelectric" OR "hydro electric" OR "hydropower" OR "marine energy" OR "tidal energy" OR "wave energy"
               )

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -1,6 +1,6 @@
 # Search query for SDG 7 - Affordable and clean energy, Bergen topic-approach.
 
-**Current status**: This string is currently a finished version.
+**Current status**: This string is currently being edited after testing.
 
 **Contents**
 
@@ -12,7 +12,7 @@
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here: https://www.webofscience.com/wos/woscc/summary/d154b0d3-89dc-465a-84c8-ec84a0fe5854-57bae169/relevance/1 (no filters; all years)
+Results of the full search in its current state can be viewed on Web of Science by clicking here:  (no filters; all years)
 
 ## 2. General notes
 

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -105,7 +105,7 @@ TS=
   )    
   NEAR/15
       ("household$" OR "homes" OR "house" OR "houses" OR "housing"
-      OR "residential" OR "dwelling$" OR "domestic use*" OR "slum" OR "slums" OR "women"
+      OR "residential" OR "dwelling$" OR "domestic use*" OR "slum" OR "slums" 
       OR "residential heating" OR "central heating" OR "winter heating" OR "cooking" OR "stove$" OR "lighting" OR "lamps"
       )      
 )
@@ -115,7 +115,7 @@ TS=
   ("coal")    
   NEAR/15
       ("household$" OR "homes" OR "house" OR "houses" OR "housing"
-      OR "residential" OR "dwelling$" OR "domestic use*" OR "slum" OR "slums" OR "women"
+      OR "residential" OR "dwelling$" OR "domestic use*" OR "slum" OR "slums" 
       OR "heating" OR "cooking" OR "stove$" OR "lighting" OR "lamps"
       )      
 )

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -10,7 +10,7 @@
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters; publication year = last 5 years): https://www.webofscience.com/wos/woscc/summary/48102699-d0f9-4682-bd31-e7c58c425164-a8639e82/relevance/1
+Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters; publication year = last 5 years): https://www.webofscience.com/wos/woscc/summary/06eb82ec-0902-443f-8084-fad50929c260-b777977d/relevance/1
 
 ## 2. General notes
 
@@ -651,7 +651,7 @@ NOT
 
 * Testing v1.2.2: Project group; see documentation https://doi.org/10.5281/zenodo.8386611
 
-* v1.3.0: Eli Heldaas Seland (Aug-Sep 2023), minor review Håkon Magne Bjerkan.
+* v2.0.0: Eli Heldaas Seland (Aug-Sep 2023), minor review Håkon Magne Bjerkan.
 
 Specialist input: Shayan Shokrgozar (PhD candidate in energy transitions research, Jul 2022)
 

--- a/SDG07_query_topic_WoS.md
+++ b/SDG07_query_topic_WoS.md
@@ -196,7 +196,7 @@ This phrase finds works about affordability and reliability of energy services. 
 ```py
 TS=
 (
-  ("stable" OR "stability" OR "reliab*" OR "resilien*" OR "afford*" OR "inexpensive" OR "low cost" OR "cheap"
+  ("stable" OR "stability" OR "reliab*" OR "secur*" OR "resilien*" OR "afford*" OR "inexpensive" OR "low cost" OR "cheap"
   OR "unstable" OR "instability" OR "unreliab*" OR "unafford*" OR "costly" OR "energy cost$" OR "expensive"
   )
   NEAR/15


### PR DESCRIPTION
# Edit SDG07

## Target 7.1
- Added "secur*" as search term alongside stable, reliable etc. for energy services in phrase 6, to catch titles where security is used outside the exact phrase "energy security" in phrase 4, e.g. "security of energy services". (#42)
- Removed "women" from phrase 3, both approaches, as it adds more noise than useful hits, especially in topic approach
- Removed "village$" from phrase 3 in action approach as it adds more noise than useful hits + to (re-)harmonize with topic approach 
- Replaced "coal" as term for dirty fuel in the second part with ("kerosene" OR "solid fuel$") to address the problems caused by "coal" + "heating" in phrase 3 (#18)

## Target 7.2
- changed the interpretation of the target and edited phrase 3 considerably in both topic and action approach  (#41)  
- removed "solar" from "solar photovoltaic$" as it was an unnecessary limitation

## Target 7.3
- Added "energy-saving" to energy terms in phrase 1 (#135)

## Target 7.a
- Removed "cleantech" and replaced "green", "greener", "clean", "cleaner" with phrases "green* energy" and "clean*energy" in phrase 1 (#64) 
- Added "clean energy" as search term alongside terms for electrical infrastructure in phrase 2 (#136)