### PR TITLE
Edit SDG14 (WoS)

### DIFF
--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -1063,7 +1063,7 @@ TS =
 
 The general structure is *action + international law + sustainable use/conservation*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**.
 
-Phrase 2 includes general phrases for international law, where sustainable use and conservation must be specified to prevent results about e.g. shipping/territory disputes.  
+Phrase 2 includes general phrases for international law, where sustainable use and conservation must be specified to prevent results about e.g. shipping/territory disputes.  Regions are added as synonyms for "international" - this seems to result in better recall (catching works about regional cooperation/instruments). Some regions are not included as too noisy (`america$`, `atlantic`). `africa$` is slightly noisy due to South Africa, but also finds several relevant works.
 
 ```py
 TS =
@@ -1074,7 +1074,7 @@ TS =
     OR "reform*" OR "improv*" OR "better"  
     )
     NEAR/5
-        ("international"
+        (("international" OR "UN" OR "europe*" OR "pacific" OR "asia$" OR "africa$" OR "latin america$" OR "*arctic")
         NEAR/3 ("governance" OR "law$" OR "policy" OR "policies" OR "regulat*" OR "legal*" OR "legislat*" OR "agreement$" OR "treaty" OR "treaties" OR "framework$" OR "instrument$")
         )
   )

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -791,6 +791,7 @@ TS =
       NEAR/5
           ("econom*" OR "GDP" OR "wealth"
           OR "exploit*" OR "goods and services" OR "ecosystem service$"
+          OR "marine resources" OR "biological resources" OR "genetic resources"
           OR "socio economic" OR "socioeconomic"
           OR "livelihood$" OR "job$" OR "income$" OR "profit*"
           OR "trade" OR "trading" OR "market$"
@@ -800,7 +801,7 @@ TS =
           )
     )
     AND
-      ("sustainab*"
+      ("sustainab*" OR "marine conservation"
       OR "marine spatial planning" OR "MSP"
       OR "ecosystem based management" OR "ecosystem based fisheries management" OR "EBFM" OR "ecosystem approach"
       OR "area based management" OR "resilience based management" OR "community based management"
@@ -808,7 +809,7 @@ TS =
       OR "coastal resources management"
       OR "locally managed marine area$" OR "LMMA$"
       OR "marine protected area$" OR "MPA" OR "MPAs" OR "LSMPA$" OR "marine reserve$" OR "ocean reserve$" OR "marine park$"
-      OR "marine conservation zone$" OR "particularly sensitive sea areas$"
+      OR "particularly sensitive sea areas$"
       OR "regional fisheries management organi?ation$" OR "RFMOs"
       OR "port state measures agreement"
       OR "fish stocks agreement" OR "UNFSA" OR "Management of Straddling Fish Stocks" OR "Management of Highly Migratory Fish Stocks"

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -903,7 +903,7 @@ TS=
           ("benefit$"
           OR "sustainable development" OR "development intervention$" OR "human development" OR "social development" OR "*economic development"
           OR "tourism" OR "ecotourism" OR "tourist$" OR "sightsee*"
-          OR "fisher*" OR "fishing" OR "aquaculture" OR "fish farm*" OR "harvest*" OR "aquarium trade"
+          OR "fisher*" OR "fishing" OR "aquaculture" OR "mariculture" OR "fish farm*" OR "harvest*" OR "aquarium trade"
           OR "exploit*" OR "goods and services" OR "ecosystem service$"
           OR "social ecological" OR "socialecological" OR "socioecological" OR "socio economic" OR "socioeconomic"
           OR "econom*" OR "GDP" OR "wealth" OR "monetary" OR "moneti*" OR "investor$"

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -2,7 +2,7 @@
 
 Conserve and sustainably use the oceans, seas and marine resources for sustainable development.
 
-**Current status**: This string is currently a finished version.
+**Current status**: This string is currently being edited after testing.
 
 **Contents**
 
@@ -15,7 +15,7 @@ Conserve and sustainably use the oceans, seas and marine resources for sustainab
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here: https://www.webofscience.com/wos/woscc/summary/8d851a1e-d98d-41de-a91e-3dbec467564e-57be146f/relevance/1 (no filters; all years)
+Results of the full search in its current state can be viewed on Web of Science by clicking here:  (no filters; all years)
 
 ## 2. General notes
 

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -305,6 +305,7 @@ TS=
     OR "Barcelona convention"
     OR "Global Programme of Action for the Protection of the Marine Environment"
     OR "MARPOL" OR "prevention of pollution from ships"
+    OR "Stockholm convention"
     )
     AND
         (  "pollut*"
@@ -1083,12 +1084,17 @@ TS =
         OR "Convention on International Trade in Endangered Species"
         OR "Regional seas programme"
         OR "Water framework directive"
-        OR "OSPAR convention"
+        OR "Stockholm convention"
+        OR "OSPAR convention" OR "Convention for Protection of the Marine Environment of the North-East Atlantic"
         OR "Marine strategy framework directive" OR "MSFD"
         OR "Barcelona convention"
         OR "Global Programme of Action for the Protection of the Marine Environment"
         OR "MARPOL" OR "prevention of pollution from ships"
         OR "Conservation of Antarctic Living Marine Resources"
+        OR "Agreement on the Conservation of Polar Bears"
+        OR "World Heritage Convention"
+        OR "Bern convention" OR "Convention on the Conservation of European Wildlife and Natural Habitats" 
+        OR "Bonn convention" OR "Convention on the Conservation of Migratory Species of Wild Animals" 
         )
 )
 ```

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -2,8 +2,6 @@
 
 Conserve and sustainably use the oceans, seas and marine resources for sustainable development.
 
-**Current status**: This string is currently being edited after testing.
-
 **Contents**
 
 1. Full query in copy-pasteable format

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -364,7 +364,7 @@ TS=
   OR "strengthen" OR "improv*"
   )
   NEAR/5
-      ("MPA" OR "MPAs" OR "LSMPA$" OR "marine reserve$" OR "ocean reserve$" OR "marine park$"
+      ("LSMPA$" OR "marine reserve$" OR "ocean reserve$" OR "marine park$"
       OR "particularly sensitive sea area$"
       OR
         (

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -67,7 +67,8 @@ TS=
           OR "offshore" OR "fish*" OR "aquaculture" OR "shrimp" OR "shellfish"
           )
     )
-  OR 
+  OR "mariculture"
+  OR
     ("sea"
       AND
           ("marsh*" OR "wetland$" OR "bay$" OR "gulf" OR "lagoon$"

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -1111,7 +1111,7 @@ TS =
           ("international" OR "high seas" OR "ABNJ" OR "UN" 
           OR "europe*" OR "pacific" OR "asia$" OR "africa$" OR "latin america$" OR "*arctic"
           )
-          NEAR/3 ("governance" OR "law$" OR "policy" OR "policies" OR "regulat*" OR "legal*" OR "legislat*" OR "agreement$" OR "treaty" OR "treaties" OR "framework$" OR "instrument$")
+          NEAR/3 ("governance" OR "law$" OR "policy" OR "policies" OR "regulat*" OR "legal*" OR "legislat*" OR "agreement$" OR "treaty" OR "treaties" OR "convention" OR "framework$" OR "instrument$")
         )
   )
   NEAR/15

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -474,6 +474,7 @@ TS=
       OR ("no-take" NEAR/3 ("area*" OR "zone*"))
       OR "Habitats directive"
       OR "CBD" OR "HELCOM" OR "OSPAR" OR "UNEP"
+      OR "marine conservation"
       OR "Conservation of Antarctic Marine Living Resources" OR "CCAMLR"
       OR "Lima convention" OR "Nairobi convention" OR "Noumea convention" OR "Barcelona convention" OR "World heritage convention"
       OR "International coral reef initiative"
@@ -1133,8 +1134,8 @@ TS =
     )
     NEAR/5
         (
-          ("international" OR "high seas" OR "ABNJ" OR "UN" 
-          OR "europe*" OR "pacific" OR "asia$" OR "africa$" OR "latin america$" OR "*arctic"
+          ("international" OR "high seas" OR "beyond national jurisdiction" OR "ABNJ" OR "UN" 
+          OR "europe*" OR "pacific" OR "asia$" OR "africa$" OR "latin america$" OR "south america$" OR "*arctic"
           )
           NEAR/3 ("governance" OR "law$" OR "policy" OR "policies" OR "regulat*" OR "legal*" OR "legislat*" OR "agreement$" OR "treaty" OR "treaties" OR "convention" OR "framework$" OR "instrument$")
         )

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -1055,54 +1055,71 @@ TS =
 
 This target is interpreted to cover research about the implementation and development of international law for conservation and sustainable use of the oceans.
 
-This query consists of 2 phrases. Phrase 1 contains specific instruments, while phrase 2 contains generic terms for international law.
+This query consists of 3 phrases. Phrase 1 and 2 contain specific instruments (divided by whether they need to be combined with marine terms or not), while phrase 3 contains generic terms for international law.
 
 #### Phrase 1
-The general structure is *action + international law*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**.
 
-This phrase contains specific international laws relevant to conservation and sustainable use. These terms were taken from 14.1, 14.2 and 14.4. <a id="FAOfish">[FAO (2018)](#f8)</a> was used as a source of relevant legislation. `CITES` is not included as it is also a verb.
+The elements of the phrase are: *action + international law*. This phrase contains specific international laws relevant to conservation and sustainable use. These terms were taken from 14.1, 14.2 and 14.4. <a id="FAOfish">[FAO (2018)](#f8)</a> was used as a source of relevant legislation.  
 
 ```py
 TS =
 (
-    ("implement*" OR "establish*" OR "introduc*" OR "adopt*" OR "integrat*" OR "design*" OR "propos*" OR "develop*"
-    OR "ensur*" OR "enforc*" OR "ratif*" OR "fulfill*" OR "into practice" OR "praxis" OR "support*" OR "negotiat*"
-    OR "reform*" OR "improv*" OR "better"
-    )
-    NEAR/5
-        ("law of the sea" OR "UNCLOS"
-        OR "the future we want"
-        OR (("biodivers*" OR "biological diversity" OR "fish*") NEAR/3 ("beyond national jurisdiction" OR "ABNJ"))
-        OR "BBNJ" OR "high seas treaty"
-        OR "common fisheries policy"
-        OR "marine stewardship council"
-        OR "regional fisheries management organi?ation$" OR "RFMOs"
-        OR "fish stocks agreement"
-        OR "code of conduct for responsible fisheries" OR "CCRF"
-        OR "port state measures agreement"
-        OR "UNFSA" OR "Management of Straddling Fish Stocks" OR "Management of Highly Migratory Fish Stocks"
-        OR "deep-sea fisheries guidelines" OR "Management of Deep-sea Fisheries in the High Seas"
-        OR ("directive$" NEAR/3 "marine spatial planning")
-        OR "habitats directive" OR "convention on biological diversity"
-        OR "Convention on International Trade in Endangered Species"
-        OR "Regional seas programme"
-        OR "Water framework directive"
-        OR "Stockholm convention"
-        OR "OSPAR convention" OR "Convention for Protection of the Marine Environment of the North-East Atlantic"
-        OR "Marine strategy framework directive" OR "MSFD"
-        OR "Barcelona convention"
-        OR "Global Programme of Action for the Protection of the Marine Environment"
-        OR "MARPOL" OR "prevention of pollution from ships"
-        OR "Conservation of Antarctic Living Marine Resources"
-        OR "Agreement on the Conservation of Polar Bears"
-        OR "World Heritage Convention"
-        OR "Bern convention" OR "Convention on the Conservation of European Wildlife and Natural Habitats" 
-        OR "Bonn convention" OR "Convention on the Conservation of Migratory Species of Wild Animals" 
-        )
+  ("implement*" OR "establish*" OR "introduc*" OR "adopt*" OR "integrat*" OR "design*" OR "propos*" OR "develop*"
+  OR "ensur*" OR "enforc*" OR "ratif*" OR "fulfill*" OR "into practice" OR "praxis" OR "support*" OR "negotiat*"
+  OR "reform*" OR "improv*" OR "better"
+  )
+  NEAR/5
+      ("law of the sea" OR "UNCLOS"
+      OR (("biodivers*" OR "biological diversity" OR "fish*") NEAR/3 ("beyond national jurisdiction" OR "ABNJ"))
+      OR "BBNJ" OR "high seas treaty"
+      OR "common fisheries policy"
+      OR "marine stewardship council"
+      OR "regional fisheries management organi?ation$" OR "RFMOs"
+      OR "fish stocks agreement"
+      OR "code of conduct for responsible fisheries"
+      OR "port state measures agreement"
+      OR "UNFSA" OR "Management of Straddling Fish Stocks" OR "Management of Highly Migratory Fish Stocks"
+      OR "deep-sea fisheries guidelines" OR "Management of Deep-sea Fisheries in the High Seas"
+      OR ("directive$" NEAR/3 "marine spatial planning")
+      OR "Regional seas programme"
+      OR "OSPAR convention" OR "Convention for Protection of the Marine Environment of the North-East Atlantic"
+      OR "Marine strategy framework directive" OR "MSFD"
+      OR "Barcelona convention"
+      OR "Global Programme of Action for the Protection of the Marine Environment"
+      OR "MARPOL" OR "prevention of pollution from ships"
+      OR "Conservation of Antarctic Living Marine Resources"
+      OR "Agreement on the Conservation of Polar Bears"
+      )
 )
 ```
 
 #### Phrase 2
+
+The elements of the phrase are: *action + international law*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**.
+
+This phrase contains specific international laws relevant to conservation and sustainable use, that need to be combined with *marine terms*. These terms were taken from 14.1, 14.2 and 14.4. <a id="FAOfish">[FAO (2018)](#f8)</a> was used as a source of relevant legislation. `CITES` is not included as it is also a verb. 
+
+ ```py
+TS =
+(
+  ("implement*" OR "establish*" OR "introduc*" OR "adopt*" OR "integrat*" OR "design*" OR "propos*" OR "develop*"
+  OR "ensur*" OR "enforc*" OR "ratif*" OR "fulfill*" OR "into practice" OR "praxis" OR "support*" OR "negotiat*"
+  OR "reform*" OR "improv*" OR "better"
+  )
+  NEAR/5
+      ("the future we want"
+      OR "habitats directive" OR "convention on biological diversity"
+      OR "Convention on International Trade in Endangered Species"
+      OR "Water framework directive"
+      OR "Stockholm convention"
+      OR "World Heritage Convention"
+      OR "Bern convention" OR "Convention on the Conservation of European Wildlife and Natural Habitats" 
+      OR "Bonn convention" OR "Convention on the Conservation of Migratory Species of Wild Animals" 
+      )
+)
+```
+
+#### Phrase 3
 
 The general structure is *action + international law + sustainable use/conservation*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**.
 
@@ -1151,6 +1168,10 @@ TS =
 * v1.0.0 Caroline S. Armitage (Nov 2021-Sep 2022)
 
 * Internal review: Marta Lorenz, Håkon Magne Bjerkan (March 2022)
+
+* Testing v1.2.2: Project group; see documentation https://doi.org/10.5281/zenodo.8386611
+
+* v1.3.0: Caroline S. Armitage (Aug-Sep 2023), minor review Lise Vik Haugen.
 
 Specialist input: Katja Enberg (Associate professor of fisheries at UiB; review of v2019.12 in 2019), Caroline S. Armitage (PhD in marine ecology).
 

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -15,7 +15,7 @@ Conserve and sustainably use the oceans, seas and marine resources for sustainab
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here:  (no filters; all years)
+Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters; publishing year = last 5 years): https://www.webofscience.com/wos/woscc/summary/e859b1f4-bfb4-4f2c-80b4-5b23826d9aed-a830b02a/relevance/1
 
 ## 2. General notes
 

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -892,7 +892,7 @@ TS=
       OR "biodivers*" OR "biological diversity" OR "BBNJ" OR "species diversity" OR "genetic diversity" OR "genomic diversity" OR "taxonomic diversity"
       )
       AND
-          ("bioprospect*" OR "biopiracy" OR "Nagoya protocol" OR "biotech*" OR "marine natural product$" ("bioactive$" NEAR/3 ("compound*" OR "substance*"))
+          ("bioprospect*" OR "biopiracy" OR "Nagoya protocol" OR "biotech*" OR "marine natural product$" OR "bioactive$"
           OR "bio-econom*" OR "bioeconom*" OR "blue growth" OR "blue econom*" OR "blue bond$" OR "marine economy"
           )
     )

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -427,11 +427,11 @@ TS=
 
 #### Phrase 3
 
-Phrase 3 covers research about restoring, protecting, conserving or managing marine ecosystems. The general structure is *action + marine ecosystems or elements*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**.
+Phrase 3 covers research about restoring, protecting, conserving or managing marine ecosystems. The general structure is *action + conservation/management + marine ecosystems/protection instruments*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**.
 
-The *action terms* for this string are challenging because one can talk about "how to conserve the marine environment" (relevant), but could also just mention "the study was carried out in a conservation area" (less relevant). Therefore, verbs for manage/protect etc. are used alone, but other forms of these words are combined with other actions (e.g. establishing management, improving protection etc).
+The *action terms* for this string are challenging because one can talk about "how to conserve the marine environment" (relevant), but could also just mention "the study was carried out in a conservation area" (less relevant). Therefore, verbs for manage/protect etc. are used alone, but other forms of these words are combined with actions (e.g. establishing management, improving protection etc).
 
-Under the *marine ecosystems/elements*, we include habitats, elements of ocean health, elements of production, and some specific pieces of legislation to do with conservation/protection. Terms to do with ocean health include various terms to do with functioning ecosystems and services for humans, diversity at various levels (important for ecosystem functioning, resilience and services),  `key species` and `foundation species` (whose presence is important for ecosystem maintenance), and `water quality` (can be a driver of species loss).`BBNJ` is a concept most often used to highlight the difficulties conserving biodiversity beyond national waters, so any publications mentioning it are assumed to be about protection/management.
+Under the *marine ecosystems/protection instruments*, we include habitats, elements of ocean health, elements of production, and some specific pieces of legislation to do with conservation/protection. Terms to do with ocean health include various terms to do with functioning ecosystems and services for humans, diversity at various levels (important for ecosystem functioning, resilience and services),  `key species` and `foundation species` (whose presence is important for ecosystem maintenance), and `water quality` (can be a driver of species loss).`BBNJ` is a concept most often used to highlight the difficulties conserving biodiversity beyond national waters, so any publications mentioning it are assumed to be about protection/management.
 
 ```py
 TS=
@@ -448,11 +448,11 @@ TS=
       OR "preserv*" OR "support*" OR "ensur*"
       )
       NEAR/5
-        ("management" OR "conservation" OR "protection" OR "restoration" OR "rehabilitation" OR "sustainable")
+        ("management" OR "conservation" OR "protection" OR "restoration" OR "rehabilitation" OR "sustainable" OR "resilien*")
     )
   )
   NEAR/15
-      ("ecosystem$" OR "habitat$" OR "communit*"
+      ("ecosystem$" OR "habitat$" OR "ecological communit*"
       OR "mangrove$" OR "kelp bed$" OR "kelp forest$" OR "seagrass*"
       OR (("seaweed$" OR "macroalga*") NEAR/5 ("bed$" OR "assemblage$" OR "communit*"))
       OR "sponge ground$" OR "reef" OR "reefs" OR "coral$"

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -1068,7 +1068,7 @@ TS =
         ("law of the sea" OR "UNCLOS"
         OR "the future we want"
         OR (("biodivers*" OR "biological diversity" OR "fish*") NEAR/3 ("beyond national jurisdiction" OR "ABNJ"))
-        OR "BBNJ"
+        OR "BBNJ" OR "high seas treaty"
         OR "common fisheries policy"
         OR "marine stewardship council"
         OR "regional fisheries management organi?ation$" OR "RFMOs"
@@ -1107,8 +1107,11 @@ TS =
     OR "reform*" OR "improv*" OR "better"  
     )
     NEAR/5
-        (("international" OR "UN" OR "europe*" OR "pacific" OR "asia$" OR "africa$" OR "latin america$" OR "*arctic")
-        NEAR/3 ("governance" OR "law$" OR "policy" OR "policies" OR "regulat*" OR "legal*" OR "legislat*" OR "agreement$" OR "treaty" OR "treaties" OR "framework$" OR "instrument$")
+        (
+          ("international" OR "high seas" OR "ABNJ" OR "UN" 
+          OR "europe*" OR "pacific" OR "asia$" OR "africa$" OR "latin america$" OR "*arctic"
+          )
+          NEAR/3 ("governance" OR "law$" OR "policy" OR "policies" OR "regulat*" OR "legal*" OR "legislat*" OR "agreement$" OR "treaty" OR "treaties" OR "framework$" OR "instrument$")
         )
   )
   NEAR/15
@@ -1122,10 +1125,11 @@ TS =
     OR "herbivore management area$"
     OR "ecosystem approach*"
     OR "MPA" OR "MPAs" OR "LSMPA$" OR "marine protected area$"
-    OR "marine reserve$" OR "ocean reserve$" OR "marine park$"
-    OR "marine conservation zone$"
+    OR "marine reserve$" OR "ocean reserve$" OR "nature reserve$" OR "marine park$"
+    OR "marine conservation zone$" OR "marine sanctuar*"
     OR "particularly sensitive sea areas$"
     OR "blue growth" OR "blue econom*"
+    OR "biodiversity" OR "biological diversity"
     )
 )
 ```

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -436,7 +436,7 @@ Under the *marine ecosystems/elements*, we include habitats, elements of ocean h
 ```py
 TS=
 (
-  ("manage" OR "conserve" OR "protect" OR "restore"
+  ("manage" OR "conserve" OR "protect" OR "restore" OR "rehabilitate"
   OR
     (
       ("designat*" OR "placement" OR "expand*" OR "extend"
@@ -448,7 +448,7 @@ TS=
       OR "preserv*" OR "support*" OR "ensur*"
       )
       NEAR/5
-        ("management" OR "conservation" OR "protection" OR "restoration" OR "sustainable")
+        ("management" OR "conservation" OR "protection" OR "restoration" OR "rehabilitation" OR "sustainable")
     )
   )
   NEAR/15
@@ -633,7 +633,7 @@ TS=
     )
     NEAR/15
       ("manag*" OR "plan" OR "planning" OR "governance"
-      OR "restor*" OR "stock recovery"
+      OR "restor*" OR "stock recovery" OR "rehabilita*"
       OR "sustainab*"
       OR "EBFM" OR "ecosystem approach*"
       OR "maximum sustainable yield*" OR "MSY"

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -351,7 +351,7 @@ This query consists of 3 phrases. Phrase 1 covers the establishment/management o
 
 This phrase covers the establishment/management of protected areas. The general structure is *action + protected areas*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**.
 
-For our interpretation of "protection" we include several types of protected areas (which have different degrees of protection); for example, `no take zone$`, `conservation zone$`, `marine protected area$`. The phrase `"protect*" OR "conservation" NEAR/3 "area*" or "zone"` will cover "marine protected areas" and "marine conservation zones". `MPA OR MPAs` is combined with `marine` as without this there are issues with other acronyms (particularly marine predator algorithm (MPA), units of pressure (MPa), Model predication across scales (MPAS)) - this is much more of an issue in the topic approach, but the same change is implemented here for consistency. 
+For our interpretation of "protection" we include several types of protected areas (which have different degrees of protection); for example, `no take zone$`, `conservation zone$`, `marine protected area$`. The phrase `"protect*" OR "conservation" NEAR/3 "area*" or "zone"` will cover "marine protected areas" and "marine conservation zones". `MPA OR MPAs` is combined with `marine protected area$` as without this there are issues with other acronyms (particularly marine predator algorithm (MPA), units of pressure (MPa)) - the abbreviation is still included as a search term in the action approach however, as it often occurs together with action terms (after being defined earlier in the abstract, for example). 
 
 ```py
 TS=
@@ -389,7 +389,7 @@ TS=
     )
     NEAR/5 ("MPA" OR "MPAs")
   )
-  AND "marine"
+  AND "marine protected area$"
 )
 ```
 
@@ -668,7 +668,7 @@ The target is interpreted to cover research about the establishment and manageme
 
 This query consists of 1 phrase. The general structure is *action + protected areas*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**. The phrase is identical to 14.2 phrase 1.
 
-Conserving areas of the ocean is considered widely to include several types of protected areas (which have different degrees of protection); for example, `no take zone$`, `conservation zone$`, `marine protected area$`. The phrase `"protect*" OR "conservation" NEAR/3 "area*" or "zone"` will cover "marine protected areas" and "marine conservation zones". For the action terms, I tested with `("increas*" NEAR/3 ("cover" OR "area" OR "size" OR "extent" OR "coverage"))` but it mostly gave noise. `MPA OR MPAs` is combined with `marine` as without this there are issues with other acronyms (particularly marine predator algorithm (MPA), units of pressure (MPa), Model predication across scales (MPAS)) - this is much more of an issue in the topic approach, but the same change is implemented here for consistency. 
+Conserving areas of the ocean is considered widely to include several types of protected areas (which have different degrees of protection); for example, `no take zone$`, `conservation zone$`, `marine protected area$`. The phrase `"protect*" OR "conservation" NEAR/3 "area*" or "zone"` will cover "marine protected areas" and "marine conservation zones". For the action terms, I tested with `("increas*" NEAR/3 ("cover" OR "area" OR "size" OR "extent" OR "coverage"))` but it mostly gave noise. `MPA OR MPAs` is combined with `marine protected area$` as without this there are issues with other acronyms (particularly marine predator algorithm (MPA), units of pressure (MPa)) - the abbreviation is still included as a search term in the action approach however, as it often occurs together with action terms (after being defined earlier in the abstract, for example). 
 
 ```py
 TS=
@@ -706,7 +706,7 @@ TS=
     )
     NEAR/5 ("MPA" OR "MPAs")
   ) 
-  AND "marine"
+  AND "marine protected area$"
 )
 ```
 

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -488,7 +488,7 @@ TS=
 >
 > 14.3.1 Average marine acidity (pH) measured at agreed suite of representative sampling stations
 
-The target is interpreted to cover research that focuses on minimising the impacts of ocean acidification (OA). We interpret "address" also as a term meaning to limit/combat, and consider research about improving resilience/reducing vulnerability to OA as relevant, as well as research about what decreases resilience. Note that this is quite a strict interpretation - there is much research about understanding and documenting the effects of ocean acidification, but research about *reducing* these effects may be much less. The topic approach covers a wider interpretation. 
+The target is interpreted to cover research that focuses on minimising the impacts of ocean acidification (OA), which includes research about what improves/reduces resilience/vulnerability to OA. We interpret "address" to mean that research about monitoring the impacts of OA is relevant too. Note that this is quite a strict interpretation - there is much research about understanding and documenting the effects of ocean acidification, but research about *reducing* these effects may be much less. The topic approach covers a wider interpretation. 
 
 The general structure is *action + impacts + acidification*.
 
@@ -504,7 +504,8 @@ TS =
       (
         ("decreas*" OR "minimi*" OR "reduc*" OR "limit" OR "mitigat*" OR "alleviat*"
         OR "fight*" OR "combat*" OR "tackl*" OR "resist*"
-        OR "stop*" OR "avoid*" OR "prevent*" OR "halt*"       
+        OR "stop*" OR "avoid*" OR "prevent*" OR "halt*" 
+        OR "monitor*"      
         )
         NEAR/5
           ("impact*" OR "effect$" OR "affect$" OR "response$" OR "consequence$"

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -718,14 +718,14 @@ TS=
 >
 >  14.6.1 Degree of implementation of international instruments aiming to combat illegal, unreported and unregulated fishing
 
-This target is interpreted to cover research about reducing/eliminating fisheries subsidies that contribute to negative outcomes (overcapacity, overfishing, and IUU finishing). We also consider research about fisheries and development assistance, fisheries and the WTO, or fisheries and the mandates mentioned in the target to be relevant.
+This target is interpreted to cover research about reducing or reform of fisheries subsidies. We also consider research about fisheries and development assistance, fisheries and the WTO, or fisheries and the mandates mentioned in the target to be relevant.
 
 This query consists of 2 phrases. 
 
 #### Phrase 1
 The general structure is *action + subsidies + fisheries*. 
 
-The generic trm `fishing` will find "IUU fishing". `"larval subsidi*" OR "recruitment subsidi*"` are terms to do with fish population dynamics and are excluded.
+The generic trm `fishing` will find "IUU fishing". `"larval subsidi*" OR "recruitment subsidi*"` are terms to do with fish population dynamics and are excluded. `subsidy` and other terms are written out rather than truncated due to "subsidence" and "subsideded".
 
 ```py
 TS =
@@ -737,7 +737,7 @@ TS =
       OR "remov*" OR "end" OR "ending" OR "prevent*" OR "stop*" OR "halt*"
       OR "reform*"
       )
-      NEAR/5 "subsid*"
+      NEAR/5 ("subsidy" OR "subsidies" OR "subsidiz*" OR "subsidis*")
     )
     NEAR/15
         ("fishing" OR "fisher*" OR "overfishing" OR "bycatch" OR "trawling"
@@ -755,7 +755,9 @@ The general structure is *ODA/mandates/WTO + fisheries*. Note that this does not
 ```py
 TS=
 (
-  ("ODA" OR "official development assistance" OR "doha development agenda" OR "hong kong ministerial" OR "world trade organization" OR "WTO")
+  ("ODA" OR "development assistance" OR "development aid" OR "development intervention$" OR "foreign aid" 
+  OR "doha development agenda" OR "hong kong ministerial" OR "world trade organization" OR "WTO"
+  )
   NEAR/15
       ("fishing" OR "fisher*" OR "overfishing"
       OR (("harvest*" OR "overcapacity") NEAR/15 ("fish*" OR "shellfish*"))

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -944,7 +944,7 @@ TS=
           OR "econom*" OR "GDP" OR "wealth" OR "monetary" OR "moneti*" OR "investor$"
           OR "livelihood$" OR "job$" OR "income$" OR "profit*"
           OR "trade" OR "trading" OR "market$"
-          OR ("sustainab*" NEAR/5 ("utilization" OR "use" OR "using" OR "usage"))
+          OR "utili$ation" OR "sustainab* use" OR "using sustainab*" OR "sustainab* usage"
           )
     )
   )

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -350,7 +350,7 @@ This query consists of 3 phrases. Phrase 1 covers the establishment/management o
 
 This phrase covers the establishment/management of protected areas. The general structure is *action + protected areas*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**.
 
-For our interpretation of "protection" we include several types of protected areas (which have different degrees of protection); for example, `no take zone$`, `conservation zone$`, `marine protected area$`. The phrase `"protect*" OR "conservation" NEAR/3 "area*" or "zone"` will cover "marine protected areas" and "marine conservation zones".
+For our interpretation of "protection" we include several types of protected areas (which have different degrees of protection); for example, `no take zone$`, `conservation zone$`, `marine protected area$`. The phrase `"protect*" OR "conservation" NEAR/3 "area*" or "zone"` will cover "marine protected areas" and "marine conservation zones". `MPA OR MPAs` is combined with `marine` as without this there are issues with other acronyms (particularly marine predator algorithm (MPA), units of pressure (MPa), Model predication across scales (MPAS)) - this is much more of an issue in the topic approach, but the same change is implemented here for consistency. 
 
 ```py
 TS=
@@ -373,6 +373,22 @@ TS=
         )
       OR ("no-take" NEAR/3 ("area$" OR "zone*" OR "reserve$")) OR "NTMR$"
       )
+)
+OR 
+TS=
+(
+  (
+    ("designat*" OR "placement" OR "delineat*" OR "expand*" OR "extend"
+    OR "design" OR "designing" OR "create" OR "creation" OR "creating" OR "develop" OR "development"
+    OR "establish*" OR "propose*" OR "proposal$" OR "implement*" OR "prioriti$e"
+    OR "plans" OR "plan" OR "planned" OR "planning"
+    OR "policy" OR "policies" OR "initiativ*" OR "framework" OR "governance" OR "manag*"
+    OR "enforce" OR "enforcement" OR "enforcing"
+    OR "strengthen" OR "improv*"
+    )
+    NEAR/5 ("MPA" OR "MPAs")
+  )
+  AND "marine"
 )
 ```
 
@@ -639,6 +655,7 @@ TS=
       )
 )
 ```
+
 ### Target 14.5
 
 > **14.5 By 2020, conserve at least 10 per cent of coastal and marine areas, consistent with national and international law and based on the best available scientific information**
@@ -649,7 +666,7 @@ The target is interpreted to cover research about the establishment and manageme
 
 This query consists of 1 phrase. The general structure is *action + protected areas*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**. The phrase is identical to 14.2 phrase 1.
 
-Conserving areas of the ocean is considered widely to include several types of protected areas (which have different degrees of protection); for example, `no take zone$`, `conservation zone$`, `marine protected area$`. The phrase `"protect*" OR "conservation" NEAR/3 "area*" or "zone"` will cover "marine protected areas" and "marine conservation zones". For the action terms, I tested with `("increas*" NEAR/3 ("cover" OR "area" OR "size" OR "extent" OR "coverage"))` but it mostly gave noise.
+Conserving areas of the ocean is considered widely to include several types of protected areas (which have different degrees of protection); for example, `no take zone$`, `conservation zone$`, `marine protected area$`. The phrase `"protect*" OR "conservation" NEAR/3 "area*" or "zone"` will cover "marine protected areas" and "marine conservation zones". For the action terms, I tested with `("increas*" NEAR/3 ("cover" OR "area" OR "size" OR "extent" OR "coverage"))` but it mostly gave noise. `MPA OR MPAs` is combined with `marine` as without this there are issues with other acronyms (particularly marine predator algorithm (MPA), units of pressure (MPa), Model predication across scales (MPAS)) - this is much more of an issue in the topic approach, but the same change is implemented here for consistency. 
 
 ```py
 TS=
@@ -663,7 +680,7 @@ TS=
   OR "strengthen" OR "improv*"
   )
   NEAR/5
-      ("MPA" OR "MPAs" OR "LSMPA$" OR "marine reserve$" OR "ocean reserve$" OR "marine park$"
+      ("LSMPA$" OR "marine reserve$" OR "ocean reserve$" OR "marine park$"
       OR "particularly sensitive sea area$"
       OR
         (
@@ -672,6 +689,22 @@ TS=
         )
       OR ("no-take" NEAR/3 ("area$" OR "zone*" OR "reserve$")) OR "NTMR$"
       )
+)
+OR 
+TS= 
+(
+  (
+    ("designat*" OR "placement" OR "delineat*" OR "expand*" OR "extend"
+    OR "design" OR "designing" OR "create" OR "creation" OR "creating" OR "develop" OR "development"
+    OR "establish*" OR "propose*" OR "proposal$" OR "implement*" OR "prioriti$e"
+    OR "plans" OR "plan" OR "planned" OR "planning"
+    OR "policy" OR "policies" OR "initiativ*" OR "framework" OR "governance" OR "manag*"
+    OR "enforce" OR "enforcement" OR "enforcing"
+    OR "strengthen" OR "improv*"
+    )
+    NEAR/5 ("MPA" OR "MPAs")
+  ) 
+  AND "marine"
 )
 ```
 

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -364,8 +364,8 @@ TS=
   OR "strengthen" OR "improv*"
   )
   NEAR/5
-      ("LSMPA$" OR "marine reserve$" OR "ocean reserve$" OR "marine park$"
-      OR "particularly sensitive sea area$"
+      ("marine reserve$" OR "ocean reserve$" OR "nature reserve$" OR "marine sanctuar*" OR "marine park$"
+      OR "particularly sensitive sea area$" OR "LSMPA$" 
       OR
         (
           ("protect*" OR "conserved" OR "conservation" OR "conserves" OR "conserving")
@@ -680,8 +680,8 @@ TS=
   OR "strengthen" OR "improv*"
   )
   NEAR/5
-      ("LSMPA$" OR "marine reserve$" OR "ocean reserve$" OR "marine park$"
-      OR "particularly sensitive sea area$"
+      ("marine reserve$" OR "ocean reserve$" OR "nature reserve$" OR "marine sanctuar*" OR "marine park$"
+      OR "particularly sensitive sea area$" OR "LSMPA$" 
       OR
         (
           ("protect*" OR "conserved" OR "conservation" OR "conserves" OR "conserving")

--- a/SDG14_query_action_WoS.md
+++ b/SDG14_query_action_WoS.md
@@ -13,7 +13,7 @@ Conserve and sustainably use the oceans, seas and marine resources for sustainab
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters; publishing year = last 5 years): https://www.webofscience.com/wos/woscc/summary/e859b1f4-bfb4-4f2c-80b4-5b23826d9aed-a830b02a/relevance/1
+Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters; publishing year = last 5 years): https://www.webofscience.com/wos/woscc/summary/dadea7c9-674a-43bf-962f-ce659ad652ee-b78159c0/relevance/1
 
 ## 2. General notes
 
@@ -1170,7 +1170,7 @@ TS =
 
 * Testing v1.2.2: Project group; see documentation https://doi.org/10.5281/zenodo.8386611
 
-* v1.3.0: Caroline S. Armitage (Aug-Sep 2023), minor review Lise Vik Haugen.
+* v2.0.0: Caroline S. Armitage (Aug-Sep 2023), minor review Lise Vik Haugen.
 
 Specialist input: Katja Enberg (Associate professor of fisheries at UiB; review of v2019.12 in 2019), Caroline S. Armitage (PhD in marine ecology).
 

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -501,7 +501,8 @@ The terms for Senegal and Anguilla here are truncated differently than standard 
 TS =
 (
     ("econom*" OR "GDP" OR "wealth"
-    OR "exploit*" OR "goods and services" OR "ecosystem service$"
+    OR "exploit*" OR "goods and services" OR "ecosystem service$" 
+    OR "marine resources" OR "biological resources" OR "genetic resources"
     OR "socio economic" OR "socioeconomic"
     OR "livelihood$" OR "job$" OR "income$" OR "profit*"
     OR "trade" OR "trading" OR "market$"
@@ -510,7 +511,7 @@ TS =
     OR "blue growth" OR "blue econom*" OR "blue bond$"
     )
     AND
-      ("sustainab*"
+      ("sustainab*" OR "marine conservation" 
       OR "marine spatial planning" OR "MSP"
       OR "ecosystem based management" OR "ecosystem based fisheries management" OR "EBFM" OR "ecosystem approach"
       OR "area based management" OR "resilience based management" OR "community based management"
@@ -518,7 +519,7 @@ TS =
       OR "coastal resources management"
       OR "locally managed marine area$" OR "LMMA$"
       OR "marine protected area$" OR "MPA" OR "MPAs" OR "LSMPA$" OR "marine reserve$" OR "ocean reserve$" OR "marine park$"
-      OR "marine conservation zone$" OR "particularly sensitive sea areas$"
+      OR "particularly sensitive sea areas$"
       OR "regional fisheries management organi?ation$" OR "RFMOs"
       OR "port state measures agreement"
       OR "fish stocks agreement" OR "UNFSA" OR "Management of Straddling Fish Stocks" OR "Management of Highly Migratory Fish Stocks"

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -771,7 +771,7 @@ TS =
   "law of the sea" OR "UNCLOS"
   OR "the future we want"
   OR (("biodivers*" OR "biological diversity" OR "fish*") NEAR/3 ("beyond national jurisdiction" OR "ABNJ"))
-  OR "BBNJ"
+  OR "BBNJ" OR "high seas treaty"
   OR "common fisheries policy"
   OR "marine stewardship council"
   OR "regional fisheries management organi?ation$" OR "RFMOs"
@@ -803,8 +803,11 @@ Phrase 2 includes general phrases for international law, where sustainable use a
 ```py
 TS =
 (
-  (("international" OR "UN" OR "europe*" OR "pacific" OR "asia$" OR "africa$" OR "latin america$" OR "*arctic")
-  NEAR/3 ("governance" OR "law$" OR "policy" OR "policies" OR "regulat*" OR "legal*" OR "legislat*" OR "agreement$" OR "treaty" OR "treaties" OR "framework$" OR "instrument$")
+  (
+    ("international" OR "high seas" OR "ABNJ" OR "UN" 
+    OR "europe*" OR "pacific" OR "asia$" OR "africa$" OR "latin america$" OR "*arctic"
+    )
+    NEAR/3 ("governance" OR "law$" OR "policy" OR "policies" OR "regulat*" OR "legal*" OR "legislat*" OR "agreement$" OR "treaty" OR "treaties" OR "framework$" OR "instrument$")
   )
   NEAR/15
     ("conservation" OR "sustainab*" OR "ecosystem restoration"
@@ -817,10 +820,11 @@ TS =
     OR "herbivore management area$"
     OR "ecosystem approach*"
     OR "MPA" OR "MPAs" OR "LSMPA$" OR "marine protected area$"
-    OR "marine reserve$" OR "ocean reserve$" OR "marine park$"
-    OR "marine conservation zone$"
+    OR "marine reserve$" OR "ocean reserve$" OR "nature reserve$" OR "marine park$"
+    OR "marine conservation zone$" OR "marine sanctuar*"
     OR "particularly sensitive sea areas$"
     OR "blue growth" OR "blue econom*"
+    OR "biodiversity" OR "biological diversity"
     )
 )
 ```

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -637,7 +637,7 @@ TS=
       OR "biodivers*" OR "biological diversity" OR "BBNJ" OR "species diversity" OR "genetic diversity" OR "genomic diversity" OR "taxonomic diversity"
       )
       AND
-          ("bioprospect*" OR "biopiracy" OR "Nagoya protocol" OR "biotech*" OR "marine natural product$" ("bioactive$" NEAR/3 ("compound*" OR "substance*"))
+          ("bioprospect*" OR "biopiracy" OR "Nagoya protocol" OR "biotech*" OR "marine natural product$" OR "bioactive$"
           OR "bio-econom*" OR "bioeconom*" OR "blue growth" OR "blue econom*" OR "blue bond$" OR "marine economy"
           )
     )

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -15,7 +15,7 @@ Conserve and sustainably use the oceans, seas and marine resources for sustainab
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here:  (no filters; all years)
+Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters; publication year = last 5 years): https://www.webofscience.com/wos/woscc/summary/fe245c11-113a-4317-8ba3-0991fdf707e2-a8333217/relevance/1
 
 ## 2. General notes
 

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -2,7 +2,7 @@
 
 Conserve and sustainably use the oceans, seas and marine resources for sustainable development.
 
-**Current status**: This string is currently a finished version.
+**Current status**: This string is currently being edited after testing.
 
 **Contents**
 
@@ -15,7 +15,7 @@ Conserve and sustainably use the oceans, seas and marine resources for sustainab
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here: https://www.webofscience.com/wos/woscc/summary/493fca38-35da-455c-8dca-e3f4b75c3bf6-57becf3d/relevance/1 (no filters; all years)
+Results of the full search in its current state can be viewed on Web of Science by clicking here:  (no filters; all years)
 
 ## 2. General notes
 

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -165,7 +165,7 @@ This target is interpreted to cover research about marine pollution. We consider
 
 It consists of 1 phrase. If comparing to the action approach, all 3 phrases in the action string are covered by this one.
 
-#### Phrase 1
+#### Phrase 1/2/3
 
 The elements of the phrase are: *pollution*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**.
 
@@ -224,9 +224,9 @@ Note, interpreting "protect" to include MPAs means that relevant research for th
 
 It is possible that this interpretation should be widened to cover research about changes to ecosystems and biodiversity (see also 15.4), but this is not done at present. 
 
-This query consists of 2 phrases. Phrase 1 covers research mentioning protected areas and sustainable management approaches. Phrase 2 covers research about the restoration, protection, conservation, or management of marine ecosystems.
+This query consists of 2 phrases. Phrase 1/2 covers research mentioning protected areas and sustainable management approaches (if comparing to the action approach: phrases 1 and 2 there are both covered by this phrase.). Phrase 3 covers research about the restoration, protection, conservation, or management of marine ecosystems.
 
-#### Phrase 1
+#### Phrase 1/2
 
 This phrase covers protected areas and sustainable management approaches. The elements of the phrase are: *protected areas/management*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**. If comparing to the action approach: phrases 1 and 2 there are both covered by this phrase.
 
@@ -259,9 +259,9 @@ TS=
 )
 ```
 
-#### Phrase 2
+#### Phrase 3
 
-Phrase 2 covers research about restoring, protecting, conserving or managing marine ecosystems. The elements of the phrase are: *management/conservation + marine ecosystems/protection instruments*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**. It corresponds to phrase 3 in the action approach.
+Phrase 3 covers research about restoring, protecting, conserving or managing marine ecosystems. The elements of the phrase are: *management/conservation + marine ecosystems/protection instruments*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**. It corresponds to phrase 3 in the action approach.
 
 Under the *management/conservation* terms we do not include "conserved" or "restored" because they are too generic (e.g. used in genetics); they also do not add many additional relevant results. Under the *marine ecosystems/protection instruments*, we include habitats, elements of ocean health, elements of production, and some specific pieces of legislation to do with conservation/protection. Terms to do with ocean health include various terms to do with functioning ecosystems and services for humans, diversity at various levels (important for ecosystem functioning, resilience and services),  `key species` and `foundation species` (whose presence is important for ecosystem maintenance), and `water quality` (can be a driver of species loss).`BBNJ` is a concept most often used to highlight the difficulties conserving biodiversity beyond national waters, so any publications mentioning it are likely to be about protection/management.
 

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -807,7 +807,7 @@ TS =
     ("international" OR "high seas" OR "ABNJ" OR "UN" 
     OR "europe*" OR "pacific" OR "asia$" OR "africa$" OR "latin america$" OR "*arctic"
     )
-    NEAR/3 ("governance" OR "law$" OR "policy" OR "policies" OR "regulat*" OR "legal*" OR "legislat*" OR "agreement$" OR "treaty" OR "treaties" OR "framework$" OR "instrument$")
+    NEAR/3 ("governance" OR "law$" OR "policy" OR "policies" OR "regulat*" OR "legal*" OR "legislat*" OR "agreement$" OR "treaty" OR "treaties" OR "convention" OR "framework$" OR "instrument$")
   )
   NEAR/15
     ("conservation" OR "sustainab*" OR "ecosystem restoration"

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -294,6 +294,7 @@ TS=
       OR ("no-take" NEAR/3 ("area*" OR "zone*"))
       OR "Habitats directive"
       OR "CBD" OR "HELCOM" OR "OSPAR" OR "UNEP"
+      OR "marine conservation"
       OR "Conservation of Antarctic Marine Living Resources" OR "CCAMLR"
       OR "Lima convention" OR "Nairobi convention" OR "Noumea convention" OR "Barcelona convention" OR "World heritage convention"
       OR "International coral reef initiative"
@@ -818,8 +819,8 @@ Phrase 2 includes general phrases for international law, where sustainable use a
 TS =
 (
   (
-    ("international" OR "high seas" OR "ABNJ" OR "UN" 
-    OR "europe*" OR "pacific" OR "asia$" OR "africa$" OR "latin america$" OR "*arctic"
+    ("international" OR "high seas" OR "beyond national jurisdiction" OR "ABNJ" OR "UN" 
+    OR "europe*" OR "pacific" OR "asia$" OR "africa$" OR "latin america$" OR "south america$" OR "*arctic"
     )
     NEAR/3 ("governance" OR "law$" OR "policy" OR "policies" OR "regulat*" OR "legal*" OR "legislat*" OR "agreement$" OR "treaty" OR "treaties" OR "convention" OR "framework$" OR "instrument$")
   )

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -310,13 +310,13 @@ TS=
 >
 > 14.3.1 Average marine acidity (pH) measured at agreed suite of representative sampling stations
 
-The target is interpreted to cover research about the impacts of ocean acidification (OA). We also interpret this to cover research about resilience and vulnerability to OA.
+The target is interpreted to cover research about the impacts of ocean acidification (OA). We also interpret this to cover research about resilience and vulnerability to OA. 
 
 The elements of the phrase are: *impacts + acidification*.
 
 *Acidification* terms: `ph` returns results from industrial processes, thus is combined in phrases. `OA` is a common abbreviation (e.g. osteoarthritis) and will find "okadeic acid" (shellfish poisoning) if used alone, hence the `AND ocean$` term (marine is not included, as often use "marine toxin"). Using all the marine terms (minus "marine") vs. just using `AND ocean$` actually only adds few extra results, many not relevant; likely because "ocean acidification" is such a well-established term.  
 
-*Impact terms*: General impact terms are included (e.g. `impact*`). In addition, in this topic approach we also include major biological processes that can be impacted by acidification, e.g. calcification.
+*Impact terms*: General impact terms are included (e.g. `impact*`). In addition, in the topic approach we also include major biological processes that can be impacted by acidification, e.g. calcification.
 
 ```py
 TS =

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -664,7 +664,7 @@ TS=
           ("benefit$"
           OR "sustainable development" OR "development intervention$" OR "human development" OR "social development" OR "*economic development"
           OR "tourism" OR "ecotourism" OR "tourist$" OR "sightsee*"
-          OR "fisher*" OR "fishing" OR "aquaculture" OR "fish farm*" OR "harvest*" OR "aquarium trade"
+          OR "fisher*" OR "fishing" OR "aquaculture" OR "mariculture" OR "fish farm*" OR "harvest*" OR "aquarium trade"
           OR "exploit*" OR "goods and services" OR "ecosystem service$"
           OR "social ecological" OR "socialecological" OR "socioecological" OR "socio economic" OR "socioeconomic"
           OR "econom*" OR "GDP" OR "wealth" OR "monetary" OR "moneti*" OR "investor$"

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -650,13 +650,13 @@ TS=
           ("benefit$"
           OR "sustainable development" OR "development intervention$" OR "human development" OR "social development" OR "*economic development"
           OR "tourism" OR "ecotourism" OR "tourist$" OR "sightsee*"
-          OR "fisher*" OR "fishing" OR "aquaculture" OR "fish farm*" OR "harvest*" OR "aquarium trade"
+          OR "fisher*" OR "fishing" OR "aquaculture" OR "mariculture" OR "fish farm*" OR "harvest*" OR "aquarium trade"
           OR "exploit*" OR "goods and services" OR "ecosystem service$"
           OR "social ecological" OR "socialecological" OR "socioecological" OR "socio economic" OR "socioeconomic"
           OR "econom*" OR "GDP" OR "wealth" OR "monetary" OR "moneti*" OR "investor$"
           OR "livelihood$" OR "job$" OR "income$" OR "profit*"
           OR "trade" OR "trading" OR "market$"
-          OR ("sustainab*" NEAR/5 ("utilization" OR "use" OR "using" OR "usage"))
+          OR "utili$ation" OR "sustainab* use" OR "using sustainab*" OR "sustainab* usage"
           )
     )
     OR
@@ -672,7 +672,7 @@ TS=
           OR "econom*" OR "GDP" OR "wealth" OR "monetary" OR "moneti*" OR "investor$"
           OR "livelihood$" OR "job$" OR "income$" OR "profit*"
           OR "trade" OR "trading" OR "market$"
-          OR ("sustainab*" NEAR/5 ("utilization" OR "use" OR "using" OR "usage"))
+          OR "utili$ation" OR "sustainab* use" OR "using sustainab*" OR "sustainab* usage"
           )
     )
   )

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -1,5 +1,4 @@
 # Search query for SDG 14 - Life below water, Bergen topic-approach.
-
 Conserve and sustainably use the oceans, seas and marine resources for sustainable development.
 
 **Contents**
@@ -13,7 +12,7 @@ Conserve and sustainably use the oceans, seas and marine resources for sustainab
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters; publication year = last 5 years): https://www.webofscience.com/wos/woscc/summary/fe245c11-113a-4317-8ba3-0991fdf707e2-a8333217/relevance/1
+Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters; publication year = last 5 years): https://www.webofscience.com/wos/woscc/summary/f5bb6c7e-2b78-4623-a253-e1340bff5ca3-b781bdd9/relevance/1
 
 ## 2. General notes
 
@@ -889,7 +888,7 @@ NOT
 
 * Testing v1.2.2: Project group; see documentation https://doi.org/10.5281/zenodo.8386611
 
-* v1.3.0: Caroline S. Armitage (Aug-Sep 2023), minor review Lise Vik Haugen.
+* v2.0.0: Caroline S. Armitage (Aug-Sep 2023), minor review Lise Vik Haugen.
 
 Specialist input: Katja Enberg (Associate professor of fisheries at UiB; review of v2019.12 in 2019), Caroline S. Armitage (PhD in marine ecology).
 

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -2,8 +2,6 @@
 
 Conserve and sustainably use the oceans, seas and marine resources for sustainable development.
 
-**Current status**: This string is currently being edited after testing.
-
 **Contents**
 
 1. Full query in copy-pasteable format

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -67,7 +67,8 @@ TS=
           OR "offshore" OR "fish*" OR "aquaculture" OR "shrimp" OR "shellfish"
           )
     )
-  OR 
+  OR "mariculture"
+  OR
     ("sea"
       AND
           ("marsh*" OR "wetland$" OR "bay$" OR "gulf" OR "lagoon$"

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -758,35 +758,28 @@ TS =
 
 This target is interpreted to cover research about international law for conservation and sustainable use of the oceans, or about international instruments related to sustainability/conservation.
 
-This query consists of 2 phrases. Phrase 1 contains specific instruments, while phrase 2 contains generic terms for international law.
+This query consists of 3 phrases. Phrase 1 and 2 contain specific instruments (divided by whether they need to be combined with marine terms or not), while phrase 3 contains generic terms for international law.
 
 #### Phrase 1
 
-The elements of the phrase are: *international law*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**.
-
-This phrase contains specific international laws relevant to conservation and sustainable use. These terms were taken from 14.1, 14.2 and 14.4. <a id="FAOfish">[FAO (2018)](#f8)</a> was used as a source of relevant legislation. `CITES` is not included as it is also a verb.
+The elements of the phrase are: *international law*. This phrase contains specific international laws relevant to conservation and sustainable use. These terms were taken from 14.1, 14.2 and 14.4. <a id="FAOfish">[FAO (2018)](#f8)</a> was used as a source of relevant legislation.  
 
 ```py
 TS =
 (
   "law of the sea" OR "UNCLOS"
-  OR "the future we want"
   OR (("biodivers*" OR "biological diversity" OR "fish*") NEAR/3 ("beyond national jurisdiction" OR "ABNJ"))
   OR "BBNJ" OR "high seas treaty"
   OR "common fisheries policy"
   OR "marine stewardship council"
   OR "regional fisheries management organi?ation$" OR "RFMOs"
   OR "fish stocks agreement"
-  OR "code of conduct for responsible fisheries" OR "CCRF"
+  OR "code of conduct for responsible fisheries"
   OR "port state measures agreement"
   OR "UNFSA" OR "Management of Straddling Fish Stocks" OR "Management of Highly Migratory Fish Stocks"
   OR "deep-sea fisheries guidelines" OR "Management of Deep-sea Fisheries in the High Seas"
   OR ("directive$" NEAR/3 "marine spatial planning")
-  OR "habitats directive" OR "convention on biological diversity"
-  OR "Convention on International Trade in Endangered Species"
   OR "Regional seas programme"
-  OR "Water framework directive"
-  OR "Stockholm convention"
   OR "OSPAR convention" OR "Convention for Protection of the Marine Environment of the North-East Atlantic"
   OR "Marine strategy framework directive" OR "MSFD"
   OR "Barcelona convention"
@@ -794,13 +787,30 @@ TS =
   OR "MARPOL" OR "prevention of pollution from ships"
   OR "Conservation of Antarctic Living Marine Resources"
   OR "Agreement on the Conservation of Polar Bears"
+)
+```
+
+#### Phrase 2
+
+The elements of the phrase are: *international law*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**.
+
+This phrase contains specific international laws relevant to conservation and sustainable use, that need to be combined with *marine terms*. These terms were taken from 14.1, 14.2 and 14.4. <a id="FAOfish">[FAO (2018)](#f8)</a> was used as a source of relevant legislation. `CITES` is not included as it is also a verb. 
+
+ ```py
+TS =
+(
+  "the future we want"
+  OR "habitats directive" OR "convention on biological diversity"
+  OR "Convention on International Trade in Endangered Species"
+  OR "Water framework directive"
+  OR "Stockholm convention"
   OR "World Heritage Convention"
   OR "Bern convention" OR "Convention on the Conservation of European Wildlife and Natural Habitats" 
   OR "Bonn convention" OR "Convention on the Conservation of Migratory Species of Wild Animals" 
 )
 ```
 
-#### Phrase 2
+#### Phrase 3
 
 The elements of the phrase are: *international law + sustainable use/conservation*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**.
 
@@ -877,6 +887,10 @@ NOT
 * v1.0.0 Caroline S. Armitage (Nov 2021-Sep 2022)
 
 * Internal review: Marta Lorenz, Håkon Magne Bjerkan (March 2022), Inger Gåsemyr (minor review Sep 2022)
+
+* Testing v1.2.2: Project group; see documentation https://doi.org/10.5281/zenodo.8386611
+
+* v1.3.0: Caroline S. Armitage (Aug-Sep 2023), minor review Lise Vik Haugen.
 
 Specialist input: Katja Enberg (Associate professor of fisheries at UiB; review of v2019.12 in 2019), Caroline S. Armitage (PhD in marine ecology).
 

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -355,9 +355,9 @@ We also consider abandoned, lost and discarded gear to lie under destructive fis
 
 Specific fish species as search terms are not needed in this query because the focus is on fisheries (fisherpeople, fishermen, fishing, fishery, fisheries), not the biology of individual fish species outside of fisheries. Therefore, even publications on specific fish species must use the terms fishery etc.
 
-#### Phrase 1
+#### Phrase 1/2
 
-The elements of this phrase are: *overfishing/illegal/destructive fishing*.
+The elements of this phrase are: *overfishing/illegal/destructive fishing*. It corresponds to phrases 1 and 2 in the action approach.
 
 ```py
 TS=
@@ -378,9 +378,9 @@ TS=
 )
 ```
 
-#### Phrase 2
+#### Phrase 3
 
-The elements of this phrase are: *management/restoration + fisheries*. This phrase differs to phrases 1 in that it focuses on sustainable management, rather than  overfishing or IUU fishing.
+The elements of this phrase are: *management/restoration + fisheries*. This phrase differs to phrase 1/2 in that it focuses on sustainable management, rather than  overfishing or IUU fishing.
 
 `manag*` will find a number of terms, e.g. "science-based management", "ecosystem based (fisheries) management" (EBFM), "area based management", "fisheries management policy" etc. Policies and frameworks which call for good management are included among the *management* terms; <a id="FAOfish">[FAO (2018)](#f8)</a> was used as a source of relevant legislation. Research about both the establishment and avoidance of fishery closures is considered to be relevant to implementing good management, as is research about the max. sustainable yield.
 

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -261,14 +261,14 @@ TS=
 
 #### Phrase 2
 
-Phrase 3 covers research about restoring, protecting, conserving or managing marine ecosystems. The elements of the phrase are: *management/conservation + marine ecosystems or elements*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**.
+Phrase 2 covers research about restoring, protecting, conserving or managing marine ecosystems. The elements of the phrase are: *management/conservation + marine ecosystems or elements*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**. It corresponds to phrase 3 in the action approach.
 
 Under the *management/conservation* terms we do not include "conserved" or "restored" because they are too generic (e.g. used in genetics); they also do not add many additional relevant results. Under the *marine ecosystems/elements*, we include habitats, elements of ocean health, elements of production, and some specific pieces of legislation to do with conservation/protection. Terms to do with ocean health include various terms to do with functioning ecosystems and services for humans, diversity at various levels (important for ecosystem functioning, resilience and services),  `key species` and `foundation species` (whose presence is important for ecosystem maintenance), and `water quality` (can be a driver of species loss).`BBNJ` is a concept most often used to highlight the difficulties conserving biodiversity beyond national waters, so any publications mentioning it are likely to be about protection/management.
 
 ```py
 TS=
 (
-  ("manage" OR "managing" OR "managed" OR "conserve" OR "conserving" OR "protect" OR "protecting" OR "protected" OR "restore" OR "restoring"
+  ("manage" OR "managing" OR "managed" OR "conserve" OR "conserving" OR "protect" OR "protecting" OR "protected" OR "restore" OR "restoring" OR "rehabilita*"
   OR "management" OR "conservation" OR "protection" OR "restoration"
   )
   NEAR/15
@@ -388,7 +388,7 @@ The elements of this phrase are: *management/restoration + fisheries*. This phra
 TS=
 (
   ("manag*" OR "plan" OR "planning" OR "governance"
-  OR "restor*" OR "stock recovery"
+  OR "restor*" OR "stock recovery" OR "rehabilita*"
   OR "sustainab*"
   OR "EBFM" OR "ecosystem approach*"
   OR "maximum sustainable yield*" OR "MSY"

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -230,13 +230,14 @@ This query consists of 2 phrases. Phrase 1 covers research mentioning protected 
 
 This phrase covers protected areas and sustainable management approaches. The elements of the phrase are: *protected areas/management*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**. If comparing to the action approach: phrases 1 and 2 there are both covered by this phrase.
 
-For our interpretation of "protection" we include several types of protected areas (which have different degrees of protection); for example, `no take zone$`, `conservation zone$`, `marine protected area$`. The phrase `"protect*" OR "conservation" NEAR/3 "area*" or "zone"` will cover "marine protected areas" and "marine conservation zones". `MPA` had to be removed in the topic approach as it is used in other contexts - results should hopefully be caught by `protected NEAR area`.
+For our interpretation of "protection" we include several types of protected areas (which have different degrees of protection); for example, `no take zone$`, `conservation zone$`, `marine protected area$`. The phrase `"protect*" OR "conservation" NEAR/3 "area*" or "zone"` will cover "marine protected areas" and "marine conservation zones". `MPA OR MPAs` is combined with `marine` as without this there are issues with other acronyms (particularly marine predator algorithm (MPA), units of pressure (MPa), Model predication across scales (MPAS)) - this change removes many of these, but does sacrifice (comparatively) few works where authors use MPA without the full term anywhere.
 
 ```py
 TS=
 (
   "LSMPA$" OR "marine reserve$" OR "ocean reserve$" OR "marine park$"
   OR "particularly sensitive sea area$"
+  OR (("MPA" OR "MPAs") AND "marine")
   OR
     (
       ("protect*" OR "conserved" OR "conservation" OR "conserves" OR "conserving")
@@ -422,13 +423,14 @@ The target is interpreted to cover research marine protected areas (MPAs). This 
 
 This query consists of 1 phrase. The elements in the phrase are: *protected areas*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**.
 
-Conserving areas of the ocean is considered widely to include several types of protected areas (which have different degrees of protection); for example, `no take zone$`, `conservation zone$`, `marine protected area$`. The phrase `"protect*" OR "conservation" NEAR/3 "area*" or "zone"` will cover "marine protected areas" and "marine conservation zones".
+Conserving areas of the ocean is considered widely to include several types of protected areas (which have different degrees of protection); for example, `no take zone$`, `conservation zone$`, `marine protected area$`. The phrase `"protect*" OR "conservation" NEAR/3 "area*" or "zone"` will cover "marine protected areas" and "marine conservation zones". `MPA OR MPAs` is combined with `marine` as without this there are issues with other acronyms (particularly marine predator algorithm (MPA), units of pressure (MPa), Model predication across scales (MPAS)) - this change removes many of these, but does sacrifice (comparatively) few works where authors use MPA without the full term anywhere.
 
 ```py
 TS=
 (
-  "MPA" OR "MPAs" OR "LSMPA$" OR "marine reserve$" OR "ocean reserve$" OR "marine park$"
+  "LSMPA$" OR "marine reserve$" OR "ocean reserve$" OR "marine park$"
   OR "particularly sensitive sea area$"
+  OR (("MPA" OR "MPAs") AND "marine")
   OR
     (
       ("protect*" OR "conserved" OR "conservation" OR "conserves" OR "conserving")

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -235,8 +235,8 @@ For our interpretation of "protection" we include several types of protected are
 ```py
 TS=
 (
-  "LSMPA$" OR "marine reserve$" OR "ocean reserve$" OR "marine park$"
-  OR "particularly sensitive sea area$"
+  "marine reserve$" OR "ocean reserve$" OR "nature reserve$" OR "marine sanctuar*" OR "marine park$"
+  OR "particularly sensitive sea area$" OR "LSMPA$" 
   OR (("MPA" OR "MPAs") AND "marine")
   OR
     (
@@ -428,8 +428,8 @@ Conserving areas of the ocean is considered widely to include several types of p
 ```py
 TS=
 (
-  "LSMPA$" OR "marine reserve$" OR "ocean reserve$" OR "marine park$"
-  OR "particularly sensitive sea area$"
+  "marine reserve$" OR "ocean reserve$" OR "nature reserve$" OR "marine sanctuar*" OR "marine park$"
+  OR "particularly sensitive sea area$" OR "LSMPA$" 
   OR (("MPA" OR "MPAs") AND "marine")
   OR
     (

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -261,18 +261,18 @@ TS=
 
 #### Phrase 2
 
-Phrase 2 covers research about restoring, protecting, conserving or managing marine ecosystems. The elements of the phrase are: *management/conservation + marine ecosystems or elements*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**. It corresponds to phrase 3 in the action approach.
+Phrase 2 covers research about restoring, protecting, conserving or managing marine ecosystems. The elements of the phrase are: *management/conservation + marine ecosystems/protection instruments*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**. It corresponds to phrase 3 in the action approach.
 
-Under the *management/conservation* terms we do not include "conserved" or "restored" because they are too generic (e.g. used in genetics); they also do not add many additional relevant results. Under the *marine ecosystems/elements*, we include habitats, elements of ocean health, elements of production, and some specific pieces of legislation to do with conservation/protection. Terms to do with ocean health include various terms to do with functioning ecosystems and services for humans, diversity at various levels (important for ecosystem functioning, resilience and services),  `key species` and `foundation species` (whose presence is important for ecosystem maintenance), and `water quality` (can be a driver of species loss).`BBNJ` is a concept most often used to highlight the difficulties conserving biodiversity beyond national waters, so any publications mentioning it are likely to be about protection/management.
+Under the *management/conservation* terms we do not include "conserved" or "restored" because they are too generic (e.g. used in genetics); they also do not add many additional relevant results. Under the *marine ecosystems/protection instruments*, we include habitats, elements of ocean health, elements of production, and some specific pieces of legislation to do with conservation/protection. Terms to do with ocean health include various terms to do with functioning ecosystems and services for humans, diversity at various levels (important for ecosystem functioning, resilience and services),  `key species` and `foundation species` (whose presence is important for ecosystem maintenance), and `water quality` (can be a driver of species loss).`BBNJ` is a concept most often used to highlight the difficulties conserving biodiversity beyond national waters, so any publications mentioning it are likely to be about protection/management.
 
 ```py
 TS=
 (
   ("manage" OR "managing" OR "managed" OR "conserve" OR "conserving" OR "protect" OR "protecting" OR "protected" OR "restore" OR "restoring" OR "rehabilita*"
-  OR "management" OR "conservation" OR "protection" OR "restoration"
+  OR "management" OR "conservation" OR "protection" OR "restoration" OR "resilien*"
   )
   NEAR/15
-      ("ecosystem$" OR "habitat$" OR "communit*"
+      ("ecosystem$" OR "habitat$" OR "ecological communit*"
       OR "mangrove$" OR "kelp bed$" OR "kelp forest$" OR "seagrass*"
       OR (("seaweed$" OR "macroalga*") NEAR/5 ("bed$" OR "assemblage$" OR "communit*"))
       OR "sponge ground$" OR "reef" OR "reefs" OR "coral$"

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -785,12 +785,17 @@ TS =
   OR "Convention on International Trade in Endangered Species"
   OR "Regional seas programme"
   OR "Water framework directive"
-  OR "OSPAR convention"
+  OR "Stockholm convention"
+  OR "OSPAR convention" OR "Convention for Protection of the Marine Environment of the North-East Atlantic"
   OR "Marine strategy framework directive" OR "MSFD"
   OR "Barcelona convention"
   OR "Global Programme of Action for the Protection of the Marine Environment"
   OR "MARPOL" OR "prevention of pollution from ships"
   OR "Conservation of Antarctic Living Marine Resources"
+  OR "Agreement on the Conservation of Polar Bears"
+  OR "World Heritage Convention"
+  OR "Bern convention" OR "Convention on the Conservation of European Wildlife and Natural Habitats" 
+  OR "Bonn convention" OR "Convention on the Conservation of Migratory Species of Wild Animals" 
 )
 ```
 

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -230,14 +230,13 @@ This query consists of 2 phrases. Phrase 1 covers research mentioning protected 
 
 This phrase covers protected areas and sustainable management approaches. The elements of the phrase are: *protected areas/management*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**. If comparing to the action approach: phrases 1 and 2 there are both covered by this phrase.
 
-For our interpretation of "protection" we include several types of protected areas (which have different degrees of protection); for example, `no take zone$`, `conservation zone$`, `marine protected area$`. The phrase `"protect*" OR "conservation" NEAR/3 "area*" or "zone"` will cover "marine protected areas" and "marine conservation zones". `MPA OR MPAs` is combined with `marine` as without this there are issues with other acronyms (particularly marine predator algorithm (MPA), units of pressure (MPa), Model predication across scales (MPAS)) - this change removes many of these, but does sacrifice (comparatively) few works where authors use MPA without the full term anywhere.
+For our interpretation of "protection" we include several types of protected areas (which have different degrees of protection); for example, `no take zone$`, `conservation zone$`, `marine protected area$`. The phrase `"protect*" OR "conservation" NEAR/3 "area*" or "zone"` will cover "marine protected areas" and "marine conservation zones". The abbreviation `MPA OR MPAs` is not included in the topic approach as there are issues with other acronyms (particularly marine predator algorithm (MPA), units of pressure (MPa)) - the vast majority of items found by `MPA` alone seem to not be about MPAs. "(marine/ocean/sea) protected areas" will still be found by the string. 
 
 ```py
 TS=
 (
   "marine reserve$" OR "ocean reserve$" OR "nature reserve$" OR "marine sanctuar*" OR "marine park$"
   OR "particularly sensitive sea area$" OR "LSMPA$" 
-  OR (("MPA" OR "MPAs") AND "marine")
   OR
     (
       ("protect*" OR "conserved" OR "conservation" OR "conserves" OR "conserving")
@@ -423,14 +422,13 @@ The target is interpreted to cover research marine protected areas (MPAs). This 
 
 This query consists of 1 phrase. The elements in the phrase are: *protected areas*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**.
 
-Conserving areas of the ocean is considered widely to include several types of protected areas (which have different degrees of protection); for example, `no take zone$`, `conservation zone$`, `marine protected area$`. The phrase `"protect*" OR "conservation" NEAR/3 "area*" or "zone"` will cover "marine protected areas" and "marine conservation zones". `MPA OR MPAs` is combined with `marine` as without this there are issues with other acronyms (particularly marine predator algorithm (MPA), units of pressure (MPa), Model predication across scales (MPAS)) - this change removes many of these, but does sacrifice (comparatively) few works where authors use MPA without the full term anywhere.
+Conserving areas of the ocean is considered widely to include several types of protected areas (which have different degrees of protection); for example, `no take zone$`, `conservation zone$`, `marine protected area$`. The phrase `"protect*" OR "conservation" NEAR/3 "area*" or "zone"` will cover "marine protected areas" and "marine conservation zones". The abbreviation `MPA OR MPAs` is not included in the topic approach as there are issues with other acronyms (particularly marine predator algorithm (MPA), units of pressure (MPa)) - the vast majority of items found by `MPA` alone seem to not be about MPAs. "(marine/ocean/sea) protected areas" will still be found by the string. 
 
 ```py
 TS=
 (
   "marine reserve$" OR "ocean reserve$" OR "nature reserve$" OR "marine sanctuar*" OR "marine park$"
   OR "particularly sensitive sea area$" OR "LSMPA$" 
-  OR (("MPA" OR "MPAs") AND "marine")
   OR
     (
       ("protect*" OR "conserved" OR "conservation" OR "conserves" OR "conserving")

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -796,12 +796,12 @@ TS =
 
 The elements of the phrase are: *international law + sustainable use/conservation*. **This phrase should be combined with [marine terms](https://github.com/SDGforskning/SDGstrings_wos/blob/main/SDG14_query_action_WoS.md#3-marine-terms-string-for-limiting-certain-phrases-to-the-marine-environment) with `AND`**.
 
-Phrase 2 includes general phrases for international law, where sustainable use and conservation must be specified to prevent results about e.g. shipping/territory disputes.  
+Phrase 2 includes general phrases for international law, where sustainable use and conservation must be specified to prevent results about e.g. shipping/territory disputes. Regions are added as synonyms for "international" - this seems to result in better recall (catching works about regional cooperation/instruments). Some regions are not included as too noisy (`america$`, `atlantic`). `africa$` is slightly noisy due to South Africa, but also finds several relevant works.
 
 ```py
 TS =
 (
-  ("international"
+  (("international" OR "UN" OR "europe*" OR "pacific" OR "asia$" OR "africa$" OR "latin america$" OR "*arctic")
   NEAR/3 ("governance" OR "law$" OR "policy" OR "policies" OR "regulat*" OR "legal*" OR "legislat*" OR "agreement$" OR "treaty" OR "treaties" OR "framework$" OR "instrument$")
   )
   NEAR/15

--- a/SDG14_query_topic_WoS.md
+++ b/SDG14_query_topic_WoS.md
@@ -446,19 +446,19 @@ TS=
 >
 >  14.6.1 Degree of implementation of international instruments aiming to combat illegal, unreported and unregulated fishing
 
-This target is interpreted to cover research about fisheries subsidies that contribute to negative outcomes (overcapacity, overfishing, and IUU finishing). We also consider relevant research about development assistance and fisheries, and works talking about WTO and other instruments in the context of fisheries.
+This target is interpreted to cover research about fisheries subsidies. We also consider research about fisheries and development assistance, fisheries and the WTO, or fisheries and the mandates mentioned in the target to be relevant.
 
 This query consists of 2 phrases. 
 
 #### Phrase 1
 The general structure is *subsidies + fisheries*. 
 
-The generic trm `fishing` will find "IUU fishing". `"larval subsidi*" OR "recruitment subsidi*"` are terms to do with fish population dynamics and are excluded.
+The generic trm `fishing` will find "IUU fishing". `"larval subsidi*" OR "recruitment subsidi*"` are terms to do with fish population dynamics and are excluded. `subsidy` and other terms are written out rather than truncated due to "subsidence" and "subsideded".
 
 ```py
 TS =
 (
-  ("subsid*"
+  (("subsidy" OR "subsidies" OR "subsidiz*" OR "subsidis*")
     NEAR/15
         ("fishing" OR "fisher*" OR "overfishing" OR "bycatch" OR "trawling"
         OR (("harvest*" OR "overcapacity") NEAR/15 ("fish*" OR "shellfish*"))
@@ -475,7 +475,9 @@ The general structure is *ODA/mandates/WTO + fisheries*.
 ```py
 TS=
 (
-  ("ODA" OR "official development assistance" OR "doha development agenda" OR "hong kong ministerial" OR "world trade organization" OR "WTO")
+  ("ODA" OR "development assistance" OR "development aid" OR "development intervention$" OR "foreign aid" 
+  OR "doha development agenda" OR "hong kong ministerial" OR "world trade organization" OR "WTO"
+  )
   NEAR/15
       ("fishing" OR "fisher*" OR "overfishing"
       OR (("harvest*" OR "overcapacity") NEAR/15 ("fish*" OR "shellfish*"))


### PR DESCRIPTION
# Edit SDG14

## Marine terms
- Added `mariculture`

## Target 14.1
- Phrase 3, *Action approach only*: Added `Stockholm convention` as a pollution agreement

## Target 14.2
- Phrase 1, *Action approach only*:  Combined the acronym `MPA OR MPAs` with `marine protected area$` to avoid irrelevant works.
- Phrase 1,*Topic approach only*: Removed `MPA OR MPAs`.
- Phrase 1: Added `marine sanctuar*` and `nature reserve$` as synonyms for protected areas. 
- Phrase 3: Added `rehabilita*` and `resilien*` as terms for management/protection. Changed `communit*` to `ecological communit*` in the marine ecosystem terms, as there were a lot of result about coastal human communities.

## Target 14.3
- *Action approach only*: Added `monitor*` as an action term

## Target 14.4
- Phrase 3: Added `rehabilita*` as a synonym for restoration

## Target 14.5
- *Action approach* - Combined the acronym `MPA OR MPAs` with `marine protected area$` to avoid irrelevant works.
- Added `marine sanctuar*` and `nature reserve$` as synonyms for protected areas

## Target 14.6
- Updated the interpretation
- Phrase 1: Changed `subsid*` for `("subsidy" OR "subsidies" OR "subsidiz*" OR "subsidis*")` to avoid subsided, subsidence etc.
- Phrase 2: Updated *ODA/mandate* terms to include `"development assistance" OR "development aid" OR "development intervention$" OR "foreign aid"`

## Target 14.7
- Added `"marine resources" OR "biological resources" OR "genetic resources"` in the *economic benefits* terms
- Changed `marine conservation zone$` to `marine conservation` in the *sustainable use* terms

## Target 14.a
- Phrase 3: Added `mariculture` together with aquaculture etc.. Fixed a missing `OR` error which probably impacted results about "marine natural products" and "bioactives" in the previous versions. Simplified by removing a NEAR phrase (sustainable + use) so it became `"utili$ation" OR "sustainab* use" OR "using sustainab*" OR "sustainab* usage"`

## Target 14.c
- Split phrase 1 into 2 phrases: 1 phrase which contains international instruments only to do with the ocean (does NOT need to be combined with marine terms) and another phrase which contains general instruments (which DO need to be combined).
- Phrase 1/2: Added `high seas treaty` as an relevant international agreement ([adopted 2023](https://en.wikipedia.org/wiki/High_Seas_Treaty)); Added `"Agreement on the Conservation of Polar Bears" OR "World Heritage Convention" OR "Bern convention" OR "Convention on the Conservation of European Wildlife and Natural Habitats" OR "Bonn convention" OR "Convention on the Conservation of Migratory Species of Wild Animals" OR "Convention for Protection of the Marine Environment of the North-East Atlantic" OR "stockholm convention"`
- Phrase 3: Added regions, UN and high seas terms as synonyms for "international" - `(...OR "high seas" OR "ABNJ" OR "UN" OR "europe*" OR "pacific" OR "asia$" OR "africa$" OR "latin america$" OR "*arctic")`. Added `convention` as a synonym in "agreements". Added `"biodiversity" OR "biological diversity"` and `"nature reserve$" OR "marine sanctuar*"` as conservation/sustainable use terms. 
