### PR TITLE
Edit SDG02 (WoS)

### DIFF
--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -396,7 +396,7 @@ The basic structure of phrase 2 is *food production systems + resilience/vulnera
 
 In the *food production system* terms, production systems and species are included (i.e. species are split from production where possible so that both resilience for the species and the production system will be covered). Some species remain linked to production to avoid irrelevant results (e.g. vegetable intake and psychological resilience). `pastoral*` is limited in this phrase, as it finds results from other uses (pastoral care, religion studies).
 
-In the *resilience* terms, `tolera*` is a particularly influential term that increases results ("drought tolerance" of crops being a common research theme). `climate smart agriculture` is a term used for an approach specifically addressing climate change.
+In the *resilience* terms, `climate smart agriculture` is a term used for an approach specifically addressing climate change.
 
 ```py
 TS=
@@ -420,7 +420,8 @@ TS=
           (
             (
               ("climate smart agriculture" OR "resilien*"
-              OR (("disaster$" OR "risk$") NEAR/3 ("plan*" OR "strateg*" OR "relief" OR "manag*"))
+              OR (("disaster$" OR "risk$") NEAR/3 ("plan*" OR "strateg*" OR "relief" OR "manag*" OR "program*"))
+              OR "risk reduction"
               )
               NEAR/5
                   ("adopt*" OR "apply" OR "implement*" OR "establish*" OR "build*" OR "create" OR "creating"
@@ -449,6 +450,8 @@ The basic structure of phrase 3 is *food production systems + adaptation/coping/
 
 The *food production system* terms are the same as phrase 2.  These *disaster/climate change* terms include natural disasters, climate, market volatility, civil and political unrest (examples of risks in <a id="FAO2014">[FAO, 2014](#f7)</a>).
 
+In the *adaptation/coping/preparedness* terms, `tolera*` is a particularly influential term that increases results ("drought tolerance" of crops being a common research theme). 
+
 The *disaster* terms were taken from a standardised list we used across the SDGs, which was developed based on selected hazards listed in <a id="Murray">[Murray et al. (2021)](#f15)</a>.
 
 ```py
@@ -471,11 +474,12 @@ TS=
     )
     NEAR/15
       (
-        ("adapt*" OR "mitigat*" OR "protect*" OR "avoid*" OR "limit" OR "prevent*"
-        OR "plan" OR "planning" OR "plans" OR "policy" OR "policies" OR "strateg*" OR "framework$" OR "governance" OR "legislat*"
+        ("mitigat*" OR "protect*" OR "avoid*" OR "limit" OR "prevent*"
+        OR "sendai" OR "plan" OR "planning" OR "plans" OR "policy" OR "policies" OR "strateg*" OR "framework$" OR "governance" OR "legislat*" OR "programme$"
+        OR "adapt*"
         OR
           (
-            ("cope" OR "coping" OR "tolera*" OR "preparedness" OR "early warning")
+            ("cope" OR "coping" OR "tolera*" OR "preparedness" OR "early warning" OR "manag*" OR "relief")
             NEAR/5
               ("implement*" OR "establish*" OR "build*" OR "develop"
               OR "improv*" OR "increase" OR "increasing" OR "maintain*"

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -2,8 +2,6 @@
 
 End hunger, achieve food security and improved nutrition and promote sustainable agriculture.
 
-**Current status**: This string is currently being edited after testing.
-
 **Contents**
 
 1. Full query
@@ -14,7 +12,7 @@ End hunger, achieve food security and improved nutrition and promote sustainable
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters, publication year = last 5 years):
+Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters, publication year = last 5 years): https://www.webofscience.com/wos/woscc/summary/0969ff8f-ca52-494b-bb44-a304810f5f92-a837ae09/relevance/1
 
 ## 2. General notes
 

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -270,7 +270,7 @@ This query consists of 1 phrase. The basic structure is *productivity/access etc
 TS= (
       (
           ("intensification" 
-            NEAR/5 ("smallhold*" OR "small farm*" OR "family farm*" OR "family run farm*" OR "family owned farm*" OR "sustainable" OR "agroecolog*" OR "ecolog*")
+            NEAR/5 ("smallhold*" OR "small hold*" OR "small farm*" OR "family farm*" OR "family run farm*" OR "family owned farm*" OR "sustainable" OR "agroecolog*" OR "ecolog*")
           )  
         OR
           (
@@ -300,7 +300,7 @@ TS= (
           )
       )
       AND
-          ("smallhold*" OR "small farm*" OR "family farm*" OR "family run farm*" OR "family owned farm*" OR "home gardening"
+          ("smallhold*" OR "small hold*" OR "small farm*" OR "family farm*" OR "family run farm*" OR "family owned farm*" OR "home gardening"
           OR
             (
               ("small-scale" OR "indigenous" OR "homestead*" OR "subsistence")
@@ -340,7 +340,7 @@ This target is interpreted to cover research about
 Increasing productivity of all food production systems (i.e. without reference to sustainable/resilient practices) was not considered relevant in v1. However, the SDG indicator metadata clearly classes increased productivity as part of sustainability. Thus, it is included now.
 > "Maintaining or improving the output over time relative to the area of land used is an important aspect in  sustainability  for  a  range  of  reasons.  [...]. In a broader sense, an increase in the level of  land  productivity  enables  higher  production  while  reducing  pressure  on  increasingly  scarce  land  resources,  commonly  linked  to  deforestation  and  associated  losses  of  ecosystem  services  and biodiversity." (<a id="SDGindmetadata">[Statistics Division, 2021b, Indicator 2.4.1](#f9)</a>).
 
-Under "food production systems" we include types of agriculture, fishing and aquaculture. We do not include processing, storage, distribution, and markets, which can be considered part of a wider "sustainable food system" (<a id="SFS">[e.g. Annex 2, Annex 3 in One Planet network Sustainable Food Systems (SFS) Programme, 2020](#f8)</a>). Thus concepts such as food sovereignty are too wide. Types of farming system were expanded using MeSH (NIH) and Emtree (Embase database, Elsevier) subject vocabularies. Specific types of crops and livestock were further expanded using FAO statistical year book (<a id="FAO2013">[FAO, 2013](#f2)</a>). For crops, those listed as major crops or "important food crops" are included, while oil crops were excluded (not being food). Some specific types are covered by generic terms: e.g. Root crops are covered by `crops`, and terms such as `farm*` will cover types of farming in two words e.g. forest farms, family farms, fish farming.
+Under "food production systems" we include types of agriculture, fishing and aquaculture. We do not include processing, storage, distribution, and markets, which can be considered part of a wider "sustainable food system" (<a id="SFS">[e.g. Annex 2, Annex 3 in One Planet network Sustainable Food Systems (SFS) Programme, 2020](#f8)</a>) - unless they are connected to agriculture under umbrella terms such as `agrifood`. Thus concepts such as food sovereignty are too wide. Types of farming system were expanded using MeSH (NIH) and Emtree (Embase database, Elsevier) subject vocabularies. Specific types of crops and livestock were further expanded using FAO statistical year book (<a id="FAO2013">[FAO, 2013](#f2)</a>). For crops, those listed as major crops or "important food crops" are included, while oil crops were excluded (not being food). Some specific types are covered by generic terms: e.g. Root crops are covered by `crops`, and terms such as `farm*` will cover types of farming in two words e.g. forest farms, family farms, fish farming.
 
 This query consists of 6 phrases.
 
@@ -352,8 +352,9 @@ The general structure is *food production systems + production + action*. `inten
 TS=
 (
   (
-      ("food production" OR "food grower$"
-      OR "farm*" OR "agricultur*" OR "ecoagricultur*" OR "eco agricultur*" OR "permaculture"
+      ("food production" OR "food grower$" OR "agro food" OR "agrifood" OR "agri food"
+      OR "farm*" OR "agricultur*" OR "smallhold*" OR "small hold*"
+      OR "ecoagricultur*" OR "eco agricultur*" OR "permaculture"
       OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoral*"
       OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
       OR "aquaculture" OR "fish farm*"
@@ -401,8 +402,9 @@ In the *resilience* terms, `tolera*` is a particularly influential term that inc
 TS=
 (
   (
-      ("food production" OR "food grower$" OR "agro food"
-      OR "farm*" OR "agricultur*" OR "ecoagricultur*" OR "eco agricultur*" OR "permaculture"
+      ("food production" OR "food grower$" OR "agro food" OR "agrifood" OR "agri food"
+      OR "farm*" OR "agricultur*" OR "smallhold*" OR "small hold*"
+      OR "ecoagricultur*" OR "eco agricultur*" OR "permaculture"
       OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoralist$"
       OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
       OR "aquaculture" OR "fisher*" OR "fish farm*"
@@ -453,8 +455,9 @@ The *disaster* terms were taken from a standardised list we used across the SDGs
 TS=
 (
   (
-    ("food production" OR "food grower$" OR "agro food"
-    OR "farm*" OR "agricultur*" OR "ecoagricultur*" OR "eco agricultur*" OR "permaculture"
+    ("food production" OR "food grower$" OR "agro food" OR "agrifood" OR "agri food"
+    OR "farm*" OR "agricultur*" OR "smallhold*" OR "small hold*"
+    OR "ecoagricultur*" OR "eco agricultur*" OR "permaculture"
     OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoralist$"
     OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
     OR "aquaculture" OR "fisher*" OR "fish farm*"
@@ -529,8 +532,8 @@ OR
 TS=
 (
   (
-    ("food production" OR "food grower$" OR "agri food"
-    OR "farm*" OR "agricultur*"
+    ("food production" OR "food grower$" OR "agro food" OR "agrifood" OR "agri food"
+    OR "farm*" OR "agricultur*" OR "smallhold*" OR "small hold*"
     OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoral*"
     OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
     OR "aquaculture" OR "fisher*" OR "fish farm*"
@@ -570,8 +573,9 @@ The general structure is *food production systems + ecosystems and soil + action
 ```py
 TS=
 (
-    ("food production" OR "food grower$" OR "agri food"
-    OR "farm*" OR "agricultur*" OR "permaculture"
+    ("food production" OR "food grower$" OR "agro food" OR "agrifood" OR "agri food"
+    OR "farm*" OR "agricultur*" OR "smallhold*" OR "small hold*"
+    OR "permaculture"
     OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoral*"
     OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
     OR "aquaculture" OR "fisher*" OR "fish farm*"
@@ -610,8 +614,9 @@ Types of land/soil degradation are taken from <a id="FAO2014">[FAO (2014)](#f7)<
 ```py
 TS=
 (
-  ("food production" OR "food grower$" OR "agri food"
-  OR "farm*" OR "agricultur*" OR "permaculture"
+  ("food production" OR "food grower$" OR "agro food" OR "agrifood" OR "agri food"
+  OR "farm*" OR "agricultur*" OR "smallhold*" OR "small hold*"
+  OR "permaculture"
   OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoral*"
   OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
   OR "aquaculture" OR "fisher*" OR "fish farm*"
@@ -934,7 +939,7 @@ TS =
             OR
               (
                 ("infrastructure" OR "technolog*" OR "biotech*" OR "research" OR "science$" OR "innovation" OR "R&D")
-                NEAR/3 ("agricultur*" OR "farm*" OR "irrigation" OR "agri food" OR "agrifood")
+                NEAR/3 ("agricultur*" OR "smallhold*" OR "small hold*" OR "farm*" OR "irrigation" OR "agri food" OR "agrifood")
               )                  
             )
       )

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -320,7 +320,7 @@ TS= (
                   )
                 OR
                   (
-                    ("crop$" OR "produce" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
+                    ("crop$" OR "produce" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
                     OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
                     )
                     NEAR/5 ("production" OR "producer$" OR "grower$" OR "herder$" OR "herding")
@@ -366,14 +366,14 @@ TS=
       OR "aquaculture" OR "fish farm*" OR "mariculture"
       OR
         (
-          ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
+          ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
           OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
           )
           NEAR/5 ("production" OR "producer$" OR "grower$" OR "herder$" OR "herding" OR "ranch*" OR "plantation$")
         )  
       OR
         (
-          ("crop$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses")
+          ("crop$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$")
           NEAR/5 "yield$"
         )     
       OR "grain yield$"     
@@ -418,7 +418,7 @@ TS=
       OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoralist$"
       OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
       OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
-      OR "crop$" OR "cereal$" OR "rice" OR "wheat" OR "maize"
+      OR "crop$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "legume$"
       OR "livestock" OR "cattle" OR "sheep" OR "poultry" OR "chicken$" OR "pig$" OR "goat$"
       OR
         (
@@ -474,7 +474,7 @@ TS=
     OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoralist$"
     OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
     OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
-    OR "crop$" OR "cereal$" OR "rice" OR "wheat" OR "maize"
+    OR "crop$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "legume$"
     OR "livestock" OR "cattle" OR "sheep" OR "poultry" OR "chicken$" OR "pig$" OR "goat$"
     OR
       (
@@ -553,7 +553,7 @@ TS=
     OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
     OR
       (
-        ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
+        ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
         OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
         )
         NEAR/5 ("production" OR "producer$" OR "grower$" OR "herder$" OR "herding" OR "ranch*" OR "plantation$")
@@ -595,7 +595,7 @@ TS=
     OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
     OR
       (
-        ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
+        ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
         OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
         )
         NEAR/5 ("production" OR "producer$" OR "grower$" OR "herder$" OR "herding" OR "ranch*" OR "plantation$")
@@ -637,7 +637,7 @@ TS=
   OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
   OR   
     (
-      ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
+      ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
       OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
       )
       NEAR/5 ("production" OR "producer$" OR "grower$" OR "herder$" OR "herding" OR "ranch*" OR "plantation$")
@@ -710,7 +710,7 @@ TS=
         ("local" OR "traditional" OR "heirloom" OR "wild" OR "indigenous" OR "autochthonous")
         NEAR/1 
           ("breed$" OR "variet*" OR "cultivar$" 
-          OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
+          OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
           OR "livestock" OR "poultry" OR "cattle" OR "sheep" OR "goat$" OR "chicken$" OR "duck$" OR "buffalo*"
           )
       )
@@ -770,7 +770,7 @@ TS=
             OR "permaculture" OR "cropping system$" OR "orchard$"
             OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
             OR "aquaculture" OR "mariculture"
-            OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
+            OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
             OR "livestock" OR "poultry" OR "cattle" OR "sheep" OR "pig$" OR "goat$" OR "chicken$" OR "duck$" OR "buffalo*"      
             OR "landrace$" OR "wild relative$"
             OR
@@ -816,7 +816,7 @@ TS=
           OR "permaculture" OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
           OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
           OR "aquaculture" OR "mariculture"
-          OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
+          OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
           OR "livestock" OR "poultry" OR "cattle" OR "sheep" OR "pig$" OR "goat$" OR "chicken$" OR "duck$" OR "buffalo*"     
           OR "landrace$" OR "wild relative$"
           OR
@@ -872,7 +872,7 @@ TS=
       OR "permaculture" OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
       OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
       OR "aquaculture" OR "mariculture"
-      OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
+      OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
       OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
       OR "landrace$" OR "wild relative$"
       OR
@@ -904,7 +904,7 @@ TS =
         OR "permaculture" OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
         OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
         OR "aquaculture" OR "mariculture"
-        OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
+        OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
         OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
         OR "landrace$" OR "wild relative$"
         OR
@@ -1020,7 +1020,7 @@ TS=
   NEAR/15
       (
         ("trade" OR "trading" OR "market$" OR "export$" OR "import$")
-        NEAR/5 ("agricultur*" OR "agrifood" OR "food" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses")
+        NEAR/5 ("agricultur*" OR "agrifood" OR "food" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$")
       )
 )
 ```
@@ -1059,7 +1059,7 @@ TS=
         (
           ("price$" OR "market$")
           NEAR/5
-            ("agricultur*" OR "agrifood" OR "food" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "livestock")
+            ("agricultur*" OR "agrifood" OR "food" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$" OR "livestock")
         )
 )
 ```

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -80,7 +80,7 @@ TS=
 
 #### Phrase 2
 
-The general structure is *food access/safety/nutrition + action*. `food` should cover mechanisms such as food banks, food stamps, food credits, and descriptions such as good quality food etc. Some specific food assistance terms are also included, as these focus on ensuring that people have access to food. `nutrition* quality` does find some results about animal feed, but a number of them connect their work to food security, reducing food loss, so it is safer not to remove this term. Here we are including `food sovereignty` as it encompasses the ideas of access to safe, adequate and nutritious food, so is included here.
+The general structure is *food access/safety/nutrition + action*. `food` should cover mechanisms such as food banks, food stamps, food credits, and descriptions such as good quality food etc. Some specific food assistance terms are also included, as these focus on ensuring that people have access to food. Here we are including `food sovereignty` as it encompasses the ideas of access to safe, adequate and nutritious food, so is included here.
 
 ```py
 TS=
@@ -185,7 +185,7 @@ TS=
 
 The general structure is *(nutritional access/quality OR status + specific groups) + action*
 
-Research about improving the nutritional status of the groups mentioned in the target is included here, along with research about improving nutrition quality. `nutritio*` should cover terms such as "access to nutritional care". `baby` is not used as it only adds noise about "baby mustard".
+Research about improving the nutritional status of the groups mentioned in the target is included here, along with research about improving nutrition quality. `nutritio*` (combined with *access* etc.) should cover terms such as "access to nutritional care". `nutrition* quality` finds some results about animal feed, but a number of them connect their work to food security and reducing food loss, so it is safer to keep this term. `baby` is not used as it only adds noise about "baby mustard".
 
 ```py
 TS=

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -1001,7 +1001,7 @@ The basic structure is *export subsidies + agriculture/food*.
 TS=
 (
   ("export subsid*" OR "export credit$" OR "export financ*" OR "export competition" OR "export support$")
-  AND ("agricultur*" OR "agrifood" OR "food")
+  AND ("agricultur*" OR "agrifood" OR "food" OR "aquaculture" OR "mariculture")
 )
 ```
 
@@ -1021,7 +1021,7 @@ TS=
   NEAR/15
       (
         ("trade" OR "trading" OR "market$" OR "export$" OR "import$")
-        NEAR/5 ("agricultur*" OR "agrifood" OR "food" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$")
+        NEAR/5 ("agricultur*" OR "agrifood" OR "food" OR "aquaculture" OR "mariculture" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$")
       )
 )
 ```
@@ -1058,7 +1058,7 @@ TS=
         (
           ("price$" OR "market$")
           NEAR/5
-            ("agricultur*" OR "agrifood" OR "food" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$" OR "livestock")
+            ("agricultur*" OR "agrifood" OR "food" OR "aquaculture" OR "mariculture" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$" OR "livestock")
         )
 )
 ```

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -14,7 +14,7 @@ End hunger, achieve food security and improved nutrition and promote sustainable
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here:  (no filters, all years)
+Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters, publication year = last 5 years):
 
 ## 2. General notes
 
@@ -1073,7 +1073,9 @@ TS=
 
 * Internal review: Eli Heldaas Seland, Marta Lorenz (March 2022)
 
-* Revision after testing: Caroline S. Armitage (July 2023)
+* Testing v1.2.2: Project group; see documentation https://doi.org/10.5281/zenodo.8386611
+
+* v1.3.0: Caroline S. Armitage (Aug-Sep 2023), minor review Eli Heldaas Seland.
 
 Specialist input: Awaiting specialist input.
 

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -1033,8 +1033,6 @@ TS=
 
 This target is interpreted to cover research about preventing price volatility in food/agriculture, and about ensuring stable food commodity markets. The basic structure is *action + volatility/stability + agricultural markets/prices*.
 
-#### Phrase 1
-
 ```py
 TS=
 (

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -939,37 +939,37 @@ This query consists of 1 phrase. The general structure is *investment/cooperatio
 ```py
 TS =
 (
-      ("Agriculture Orientation Index for Government Expenditure$"
-      OR
-        ("investm*" OR "investing" OR "invest" OR "finance" OR "financial support" OR "financing" OR "funding"
-        OR "ODA" OR "cooperation fund$" OR "development spending"
-        OR (("research" OR "governm*" OR "public" OR "sector") NEAR/3 ("expenditure" OR "spending"))
-        OR "international development"
-        OR
-          (
-            ("international" OR "development" OR "foreign" OR "global" OR "intercontinental"
-            OR "european" OR "asian" OR "africa*" OR "latin america*" OR "pacific"
-            )
-            NEAR/3
-                ("cooperat*" OR "co-operat*" OR "collaborat*" OR "network$" OR "partnership$"
-                OR "aid" OR "assistance" OR "fund$" OR "grant$" OR "financial resources"
-                )
-          )
+  ("Agriculture Orientation Index for Government Expenditure$"
+  OR
+    ("investm*" OR "investing" OR "invest" OR "finance" OR "financial support" OR "financing" OR "funding"
+    OR "ODA" OR "cooperation fund$" OR "development spending"
+    OR (("research" OR "governm*" OR "public" OR "sector") NEAR/3 ("expenditure" OR "spending"))
+    OR "international development"
+    OR
+      (
+        ("international" OR "development" OR "foreign" OR "global" OR "intercontinental"
+        OR "european" OR "asian" OR "africa*" OR "latin america*" OR "pacific"
         )
-        NEAR/15
-            ("rural infrastructure" OR "rural tech*" 
-            OR ("rural development" AND ("agri*" OR "agro*" OR "smallhold*" OR "farm*"))
-            OR "agricultur* development" OR "development of agriculture"
-            OR "agronom*" OR "agroecolog*" OR "agro ecolog*" OR "agricultural sector"
-            OR "plant bank$" OR "seed bank$" OR "gene bank$" OR "genebank$" OR "germplasm bank$" OR "cryobank$"
-            OR
-              (
-                ("infrastructure" OR "technolog*" OR "biotech*" OR "research" OR "science$" OR "innovation" OR "R&D")
-                NEAR/5 ("agricultur*" OR "smallhold*" OR "small hold*" OR "farm*" OR "irrigation" OR "agri food" OR "agrifood" OR "agrofood" OR "aquaculture" OR "mariculture")
-              )                  
+        NEAR/3
+            ("cooperat*" OR "co-operat*" OR "collaborat*" OR "network$" OR "partnership$"
+            OR "aid" OR "assistance" OR "fund$" OR "grant$" OR "financial resources"
             )
       )
-      AND
+    )
+    NEAR/15
+      ("rural infrastructure" OR "rural tech*" 
+      OR ("rural development" NEAR/15 ("agri*" OR "agro*" OR "smallhold*" OR "farm*"))
+      OR "agricultur* development" OR "development of agriculture"
+      OR "agronom*" OR "agroecolog*" OR "agro ecolog*" OR "agricultural sector"
+      OR "plant bank$" OR "seed bank$" OR "gene bank$" OR "genebank$" OR "germplasm bank$" OR "cryobank$"
+      OR
+        (
+          ("infrastructure" OR "technolog*" OR "biotech*" OR "research" OR "science$" OR "innovation" OR "R&D")
+          NEAR/5 ("agricultur*" OR "smallhold*" OR "small hold*" OR "farm*" OR "irrigation" OR "agri food" OR "agrifood" OR "agrofood" OR "aquaculture" OR "mariculture")
+        )                  
+      )
+  )
+  AND
       ("least developed countr*" OR "least developed nation$"
       OR "developing countr*" OR "developing nation$" OR "developing states" OR "developing world"
       OR "less developed countr*" OR "less developed nation$" OR "under developed countr*" OR "under developed nation$" OR "underdeveloped countr*" OR "underdeveloped nation$" OR "underserved countr*" OR "underserved nation$" OR "deprived countr*" OR "deprived nation$"

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -332,10 +332,10 @@ TS= (
 > 2.4.1 Proportion of agricultural area under productive and sustainable agriculture
 
 This target is interpreted to cover research about
-* increasing the productivity of food production systems (phrase 1)
+* increasing the productivity/yield of food production systems (phrase 1)
 * implementation of resilient food production systems/agricultural practices, including strengthening adaptation and preparedness of food production systems/species to climate change and disasters (phrases 2,3)
 * increasing sustainable food production systems/practices (outside of resilience; phrase 4)
-* how food production systems can improve/maintain soil quality and ecosystems (phrase 5,6)
+* how food production systems can improve/maintain soil quality and ecosystem health (phrase 5,6)
 
 Increasing productivity of all food production systems (i.e. without reference to sustainable/resilient practices) was not considered relevant in v1. However, the SDG indicator metadata clearly classes increased productivity as part of sustainability. Thus, it is included now.
 > "Maintaining or improving the output over time relative to the area of land used is an important aspect in  sustainability  for  a  range  of  reasons.  [...]. In a broader sense, an increase in the level of  land  productivity  enables  higher  production  while  reducing  pressure  on  increasingly  scarce  land  resources,  commonly  linked  to  deforestation  and  associated  losses  of  ecosystem  services  and biodiversity." (<a id="SDGindmetadata">[Statistics Division, 2021b, Indicator 2.4.1](#f9)</a>).
@@ -346,7 +346,7 @@ This query consists of 6 phrases.
 
 #### Phrase 1
 
-The general structure is *food production systems + production + action*. `intensification` implies increasing production, but results in some noise when used alone - it can be used in other contexts, and finds many results about the *effects* of agricultural intensification, thus it is combined with other terms which limit it better to works looking at the process itself.
+The general structure is *food production systems + production + action*. `intensification` implies increasing production, but results in some noise when used alone - it can be used in other contexts, and finds many results about the *effects* of agricultural intensification, thus it is combined with other terms which limit it better to works looking at the process itself. `grain yield$` is included as a phrase, rather than being combined with NEAR, because otherwise this results in a high number of results from metallurgy. `yield$` is included in 2 parts of the string, meaning that mentioning e.g. "rice yields" is enough to be included. 
 
 ```py
 TS=
@@ -364,13 +364,17 @@ TS=
           OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
           )
           NEAR/5 ("production" OR "producer$" OR "grower$" OR "herder$" OR "herding" OR "ranch*" OR "plantation$")
-        )      
+        )  
+      OR
+        (
+          ("crop$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses")
+          NEAR/5 "yield$"
+        )     
+      OR "grain yield$"     
       )
       NEAR/15
           (
-            ("intensification"
-            NEAR/5 ("sustainable" OR "agroecolog*" OR "ecolog*")
-            )
+            ("intensification" NEAR/5 ("sustainable" OR "agroecolog*" OR "ecolog*"))
           OR
             (
               ("production" OR "productivity" OR "efficiency" OR "yield$" OR "agricultural output$" OR "farm output$")

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -965,7 +965,7 @@ TS =
 >
 > 2.b.1 Agricultural export subsidies
 
-This target is interpreted to cover research about export subsidies (and equivalents) for agricultural/food exports, and trade restrictions and distortions for world agricultural/food markets. A WTO agricultural export subsidy fact sheet (<a id="WTOexport">[Information and External Relations Division of the WTO Secretariat, n.d.](#f13)</a>) was used as a source of terms, where food aid is also a factor.
+This target is interpreted to cover research about subsidies (and equivalents), trade restrictions and distortions for world agricultural/food markets/trade. A WTO agricultural export subsidy fact sheet (<a id="WTOexport">[Information and External Relations Division of the WTO Secretariat, n.d.](#f13)</a>) was used as a source of terms, where food aid is also a factor.
 
 This query consists of 2 phrases. Note that these phrases do not contain an action element as it was considered too difficult/restrictive.
 
@@ -983,19 +983,20 @@ TS=
 
 #### Phrase 2
 
-The basic structure is *distortions + agricultural markets/exports*. Specific animals are not included due to results about restrictions in trade due to outbreaks of disease.
+The basic structure is *distortions + agricultural markets/exports/imports*. Specific animals are not included due to results about restrictions in trade due to outbreaks of disease.
 
 ```py
 TS=
 (
   ("distort*" OR "price-fixing" OR "dumping"
-  OR "trade restrict*" OR "Doha" OR "food aid"
+  OR "trade restrict*" OR "sanction$"
+  OR "Doha" OR "food aid"
   OR "state support*" OR "state financial support"
   OR "WTO dispute$"
   )
   NEAR/15
       (
-        ("trade" OR "trading" OR "market$" OR "export$")
+        ("trade" OR "trading" OR "market$" OR "export$" OR "import$")
         NEAR/5 ("agricultur*" OR "agrifood" OR "food" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses")
       )
 )

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -46,7 +46,7 @@ This target is interpreted to cover research about
 * Improving access/right to food and food safety (phrase 2)
 * Improving food supplies and food supply chains (phrase 3)
 
-Some of these topics may partially overlap with 2.2. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nuritional *security*). Research topics such as nutritional security, free school meals and undernutrition may cover both areas (i.e. address that people have enough food, and that it is of sufficient nutritional quality).
+Some of these topics may partially overlap with 2.2. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nutritional *security*). Research topics such as nutritional security, free school meals and undernutrition may cover both areas (i.e. address that people have enough food, and that it is of sufficient nutritional quality).
 
 It consists of 3 phrases. Phrase 3 uses terms which need to be combined with human terms.
 
@@ -139,7 +139,7 @@ This target is interpreted to cover research about
 - improving the nutritional quality of food
 - reducing malnutrition, and improving nutritional status for all people (including elements specific to children, girls, the elderly and pregnant women). Malnutrition includes both underweight and overweight (<a id="WHOmalnut">[WHO, 2021](#f4)</a>); this WHO factsheet was used to add terms, including specific micronutrients of worldwide importance (iodine, iron, vitamin A).
 
-Some of these topics partially overlap with 2.1, which covers access to food/food insecurity. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nuritional *security*). Research topics such as nutritional security, free school meals and undernutrition may cover both areas (i.e. address that people have enough food, and that it is of sufficient nutritional quality).
+Some of these topics partially overlap with 2.1, which covers access to food/food insecurity. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nutritional *security*). Research topics such as nutritional security, free school meals and undernutrition may cover both areas (i.e. address that people have enough food, and that it is of sufficient nutritional quality).
 
 This query consists of 3 phrases. Phrase 3 is for terms which need to be combined with human terms.
 

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -592,7 +592,7 @@ TS=
       )      
     )
     NEAR/15
-          ("soil conservation"
+          ("soil conservation" OR "soil improv*"
           OR
             (
               ("soil structure" OR "soil fertility" OR "soil health"

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -743,42 +743,42 @@ Terminology to do with breeding programmes could be included here, but we want r
 ```py
 TS=
 (
-        ("increase genetic diversity" OR "improve genetic diversity"
+  ("increase genetic diversity" OR "improve genetic diversity"
+  OR
+    (       
+      ("genetic resource$"
+      OR ("genetic" NEAR/2 "diversity")
+      )
+      NEAR/10
+        ("maintain*" OR "conserv*" OR "preserv*" OR "protect*" OR "secure" OR "securing"
         OR
-          (       
-             ("genetic resource$"
-             OR ("genetic" NEAR/2 "diversity")
-             )
-             NEAR/10
-                  ("maintain*" OR "conserv*" OR "preserv*" OR "protect*" OR "secure" OR "securing"
-                  OR
-                    (
-                      ("loss" OR "extinction" OR "declin*" OR "disappear*")
-                      NEAR/5
-                          ("decreas*" OR "minimi*" OR "reduc*" OR "limit$" OR "mitigat*"
-                          OR "lowering" OR "lower$" OR "lowered" OR "combat*"
-                          OR "stop*" OR "end" OR "ending" OR "halt"
-                          OR "avoid*" OR "prevent*"
-                          )
-                    )
-                  )
+          (
+            ("loss" OR "extinction" OR "declin*" OR "disappear*")
+            NEAR/5
+              ("decreas*" OR "minimi*" OR "reduc*" OR "limit$" OR "mitigat*"
+              OR "lowering" OR "lower$" OR "lowered" OR "combat*"
+              OR "stop*" OR "end" OR "ending" OR "halt"
+              OR "avoid*" OR "prevent*"
+              )
           )
         )
-        NEAR/15
-            ("agricultur*" OR "domestic*" OR "farming" OR "farmed" OR "farm$" OR "farmer$" OR "cultiva*" 
-            OR "smallhold*" OR "small hold*"
-            OR "permaculture" OR "cropping system$" OR "orchard$"
-            OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-            OR "aquaculture" OR "mariculture"
-            OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
-            OR "livestock" OR "poultry" OR "cattle" OR "sheep" OR "pig$" OR "goat$" OR "chicken$" OR "duck$" OR "buffalo*"      
-            OR "landrace$" OR "wild relative$"
-            OR
-              (
-                ("local*" OR "traditional" OR "heirloom" OR "wild" OR "indigenous" OR "autochthonous")
-                NEAR/3 ("breed$" OR "variet*" OR "cultivar$")
-              )
-            )
+    )
+  )
+  NEAR/15
+      ("agricultur*" OR "domestic*" OR "farming" OR "farmed" OR "farm$" OR "farmer$" OR "cultiva*" 
+      OR "smallhold*" OR "small hold*"
+      OR "permaculture" OR "cropping system$" OR "orchard$"
+      OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
+      OR "aquaculture" OR "mariculture"
+      OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
+      OR "livestock" OR "poultry" OR "cattle" OR "sheep" OR "pig$" OR "goat$" OR "chicken$" OR "duck$" OR "buffalo*"      
+      OR "landrace$" OR "wild relative$"
+      OR
+        (
+          ("local*" OR "traditional" OR "heirloom" OR "wild" OR "indigenous" OR "autochthonous")
+          NEAR/3 ("breed$" OR "variet*" OR "cultivar$")
+        )
+      )
 )
 ```
 

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -46,7 +46,7 @@ This target is interpreted to cover research about
 * Improving access/right to food and food safety (phrase 2)
 * Improving food supplies and food supply chains (phrase 3)
 
-Some of these topics may partially overlap with 2.2. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nutritional *security*). Research topics such as nutritional security, free school meals and undernutrition may cover both areas (i.e. address that people have enough food, and that it is of sufficient nutritional quality).
+Some of these topics may partially overlap with 2.2. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *value*); 2.1 is interpreted to focus on access-related issues (e.g. nutritional *security*). Research topics such as nutritional security, free school meals and undernutrition may cover both areas (i.e. address the issue of whether people have enough food, and whether it is of sufficient nutritional quality).
 
 It consists of 3 phrases. Phrase 3 uses terms which need to be combined with human terms.
 
@@ -139,7 +139,7 @@ This target is interpreted to cover research about
 - improving the nutritional quality of food
 - reducing malnutrition, and improving nutritional status for all people (including elements specific to children, girls, the elderly and pregnant women). Malnutrition includes both underweight and overweight (<a id="WHOmalnut">[WHO, 2021](#f4)</a>); this WHO factsheet was used to add terms, including specific micronutrients of worldwide importance (iodine, iron, vitamin A).
 
-Some of these topics partially overlap with 2.1, which covers access to food/food insecurity. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nutritional *security*). Research topics such as nutritional security, free school meals and undernutrition may cover both areas (i.e. address that people have enough food, and that it is of sufficient nutritional quality).
+Some of these topics partially overlap with 2.1, which covers access to food/food insecurity. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *value*); 2.1 is interpreted to focus on access-related issues (e.g. nutritional *security*). Research topics such as nutritional security, free school meals and undernutrition may cover both areas (i.e. address the issue of whether people have enough food, and whether it is of sufficient nutritional quality).
 
 This query consists of 3 phrases. Phrase 3 is for terms which need to be combined with human terms.
 

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -2,7 +2,7 @@
 
 End hunger, achieve food security and improved nutrition and promote sustainable agriculture.
 
-**Current status**: This string is currently a finished version.
+**Current status**: This string is currently being edited after testing.
 
 **Contents**
 
@@ -14,7 +14,7 @@ End hunger, achieve food security and improved nutrition and promote sustainable
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here: https://www.webofscience.com/wos/woscc/summary/b3b8d55f-4112-42a3-9c12-de4dc95f8a76-55efa21b/relevance/1 (no filters, all years)
+Results of the full search in its current state can be viewed on Web of Science by clicking here:  (no filters, all years)
 
 ## 2. General notes
 

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -42,55 +42,52 @@ During editing of this string (2021), we have consulted two other sets of querie
 > 2.1.2 Prevalence of moderate or severe food insecurity in the population, based on the Food Insecurity Experience Scale (FIES)
 
 This target is interpreted to cover research about
-* Ending/reducing hunger/lack of food, reducing food insecurity
-* Increasing access to food and improving food supply systems
-* Increasing the safety and nutritional value of the food available.
+* Ending/reducing hunger and food insecurity (phrase 1)
+* Improving access/right to food and food safety (phrase 2)
+* Improving food supplies and food supply chains (phrase 3)
+
+Some of these topics may partially overlap with 2.2. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nuritional *security*). Research topics such as nutritional security or free school meals may cover both areas (i.e. address that people have enough food, and that it is of good nutritional quality).
 
 It consists of 3 phrases. Phrase 3 uses terms which need to be combined with human terms.
 
 #### Phrase 1
 
-The general structure is *hunger + action*
+The general structure is *hunger/food insecurity + action*
 
-Hunger is used in phrases (`ending hunger`, `world hunger`) to prevent finding results that are mostly medical/physiological. `feast and famine` refers to bioreactors/selective pressure in microbial cultures (not relevant), and is used in a double NOT to avoid losing relevant results. `Underfeeding` and `starvation` removed as seem to be used mostly in a medical/physiology context, rather than related to food security/supply.
+Hunger is used in phrases (`ending hunger`, `world hunger`) to prevent finding results that are mostly medical/physiological. `feast and famine` refers to bioreactors/selective pressure in microbial cultures (not relevant). `Underfeeding` and `starvation` removed as seem to be used mostly in a medical/physiology context, rather than related to food security/supply.
 
 ```py
 TS=
 (
   (
-    ("end hunger" OR "ending hunger" OR "ends hunger" OR "world hunger"
+    ("end hunger" OR "ending hunger" OR "ends hunger" 
+    OR "world hunger" OR "child* hunger"
     OR "hunger and poverty" OR "poverty and hunger" OR "famine$"
     OR "food insecurity" OR "nutritional insecurity"
     )
     NEAR/5
-        (   "decreas*" OR "minimi*" OR "reduc*" OR "limit$" OR "limited" OR "limiting"
-            OR "alleviat*" OR "tackl*" OR "combat*" OR "fight*"
-            OR "stop*" OR "end" OR "ends" OR "ended" OR "ending" OR "eliminat*" OR "eradicat*"
-            OR "prevent*" OR "avoid*"
-            OR "manag*" OR "treat*" OR "therapy" OR "therapies" OR "intervention$"
-            OR "legislat*" OR "policy" OR "policies" OR "strateg*" OR "framework$"
+        ("decreas*" OR "minimi*" OR "reduc*" OR "limit$" OR "limited" OR "limiting"
+        OR "alleviat*" OR "tackl*" OR "combat*" OR "fight*"
+        OR "stop*" OR "end" OR "ends" OR "ended" OR "ending" OR "eliminat*" OR "eradicat*"
+        OR "prevent*" OR "avoid*"
+        OR "manag*" OR "treat*" OR "therapy" OR "therapies" OR "intervention$"
+        OR "legislat*" OR "policy" OR "policies" OR "strateg*" OR "framework$"
         )
   )
-  NOT (("feast and famine" OR "feast-famine") NOT ("end* hunger" OR "malnutrition"))    
+  NOT ("feast and famine" OR "feast-famine")    
 )
 ```
 
 #### Phrase 2
 
-The general structure is *food access/safety/nutrition + action*. `food` should cover mechanisms such as food banks, food stamps, food credits, and descriptions such as good quality food etc. `nutrition* quality` does find some results about animal feed, but a number of them connect their work to food security, reducing food loss, so it is safer not to remove this term. Here we are including `food sovereignty` as it encompasses the ideas of access to safe, adequate and nutritious food, so is included here.
+The general structure is *food access/safety/nutrition + action*. `food` should cover mechanisms such as food banks, food stamps, food credits, and descriptions such as good quality food etc. Some specific food assistance terms are also included, as these focus on ensuring that people have access to food. `nutrition* quality` does find some results about animal feed, but a number of them connect their work to food security, reducing food loss, so it is safer not to remove this term. Here we are including `food sovereignty` as it encompasses the ideas of access to safe, adequate and nutritious food, so is included here.
 
 ```py
 TS=
 (
-  ("right to food" OR "right to adequate food" OR "food sovereignty"
-  OR "nutrition* security" OR "nutrition* quality" OR "nutrition sensitive agriculture"
-  OR
-    ("food"
-    NEAR/5
-        ("access" OR "safety" OR "unsafe" OR "secure" OR "security"
-        OR "reliable" OR "reliability"    
-        )
-    )
+  ("right to food" OR "right to adequate food" OR "food sovereignty" OR "nutrition* security"
+  OR ("food" NEAR/5 ("access" OR "safety" OR "unsafe" OR "secure" OR "security" OR "reliable" OR "reliability"))
+  OR "school feeding" OR "free school meals" OR "food stamp program*" OR "nutrition assistance" OR "food assistance"
   )
   NEAR/5
      ("improv*" OR "enhanc*" OR "increas*" OR "strengthen" OR "attain" OR "achiev*"
@@ -102,20 +99,19 @@ TS=
 
 #### Phrase 3
 
-The general structure is *food supply/value + action + humans*. 
+The general structure is *food supply + action + humans*. 
 
 This phrase covers improving food supply, and is combined with "human terms" to prevent biology/ecology results. The human terms include generic terms signifying a work is about humans as well as some "vulnerable" groups (based on UN sources) considered relevant for this topic (<a id="Blanchard">[Blanchard et al., 2017](#f16)</a>; <a id="UNOHC">[Office of the High Commissioner, n.d.](#f17)</a>). Note that `food supply` will also find works about the food supply chain etc. 
 
 ```py
 TS=
  (
-    (
-      ("food supply" OR "nutritional value" OR "nutrient content" OR "nutritional content")
-      NEAR/5
-         ("improv*" OR "enhanc*" OR "increas*" OR "strengthen" OR "attain" OR "achiev*"
-         OR "ensur*" OR "guarantee" OR "secure" OR "securing" OR "maintain*" OR "manag*"
-         OR "legislat*" OR "policy" OR "policies" OR "strateg*" OR "framework$"
-         )
+    ("food supply"
+    NEAR/5
+        ("improv*" OR "enhanc*" OR "increas*" OR "strengthen" OR "attain" OR "achiev*"
+        OR "ensur*" OR "guarantee" OR "secure" OR "securing" OR "maintain*" OR "manag*"
+        OR "legislat*" OR "policy" OR "policies" OR "strateg*" OR "framework$"
+        )
     )  
     AND
         ("humans" OR "humanity" OR "human" OR "people" OR "person$"
@@ -139,7 +135,11 @@ TS=
 >
 > 2.2.3 Prevalence of anaemia in women aged 15 to 49 years, by pregnancy status (percentage)
 
-This target is interpreted to cover research about reducing malnutrition and improving the nutritional status for all people (including elements specific to children, girls, the elderly and pregnant women). Malnutrition includes both underweight and overweight (<a id="WHOmalnut">[WHO, 2021](#f4)</a>); this WHO factsheet was used to add terms, including specific micronutrients of worldwide importance (iodine, iron, vitamin A).
+This target is interpreted to cover research about 
+- improving the nutritional quality of food
+- reducing malnutrition, and improving nutritional status for all people (including elements specific to children, girls, the elderly and pregnant women). Malnutrition includes both underweight and overweight (<a id="WHOmalnut">[WHO, 2021](#f4)</a>); this WHO factsheet was used to add terms, including specific micronutrients of worldwide importance (iodine, iron, vitamin A).
+
+Some of these topics partially overlap with 2.1, which covers access to food/food insecurity. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nuritional *security*). Research topics such as nutritional security or free school meals may cover both areas (i.e. address that people have enough food, and that it is of good nutritional quality).
 
 This query consists of 3 phrases. Phrase 3 is for terms which need to be combined with human terms.
 
@@ -159,8 +159,7 @@ TS=
       OR
         (
           ("deficien*" OR "inadequa*")
-          NEAR/3
-              ("nutritional" OR "dietary" OR "vitamin$" OR "micronutrient$" OR "iron" OR "iodine")
+          NEAR/3 ("nutritional" OR "dietary" OR "vitamin$" OR "micronutrient$" OR "iron" OR "iodine")
         )
       OR
         (
@@ -184,18 +183,15 @@ TS=
 
 #### Phrase 2
 
-The general structure is *nutritional access/quality/status of specific groups + action*
+The general structure is *(nutritional access/quality OR status + specific groups) + action*
 
-Research about improving the nutritional status of the groups mentioned in the target is included here. `stability` is not used in combination with food/nutrition as there are results about nutritional stability in processed foods. `nutritio*` should cover terms such as "access to nutritional care". `baby` is not used as it only adds noise about "baby mustard".
+Research about improving the nutritional status of the groups mentioned in the target is included here, along with research about improving nutrition quality. `nutritio*` should cover terms such as "access to nutritional care". `baby` is not used as it only adds noise about "baby mustard".
 
 ```py
 TS=
 (
-  (
-    ("nutritio*"
-      NEAR/5 ("access" OR "safe" OR "unsafe" OR "secure" OR "reliable" OR "reliability")
-    )
-  OR "diet* quality" OR "nutrition* security" OR "nutrition* quality" OR "nutrition sensitive agriculture"
+  ("diet* quality" OR "nutrition* security" OR "nutrition* quality" OR "nutrition sensitive agriculture"
+  OR ("nutritio*" NEAR/5 ("access" OR "safe" OR "unsafe" OR "secure" OR "reliable" OR "reliability"))
   OR
     (
       ("nutritio*" OR "folate status" OR "micronutrient$")
@@ -205,18 +201,19 @@ TS=
           OR "old* persons" OR "old* people" OR "elderly" OR "older adult$"
           )
     )
+  OR ("nutrition*" NEAR/15 ("school feeding" OR "free school meals" OR "food stamp program*" OR "food assistance"))  
   )
   NEAR/5
-     ("improv*" OR "enhanc*" OR "increas*" OR "strengthen" OR "attain" OR "achiev*"
-     OR "ensur*" OR "guarantee" OR "secure" OR "securing" OR "maintain*" OR "manag*" OR "promote"
-     OR "legislat*" OR "policy" OR "policies" OR "strateg*" OR "framework$"
-     )
+    ("improv*" OR "enhanc*" OR "increas*" OR "strengthen" OR "attain" OR "achiev*"
+    OR "ensur*" OR "guarantee" OR "secure" OR "securing" OR "maintain*" OR "manag*" OR "promote"
+    OR "legislat*" OR "policy" OR "policies" OR "strateg*" OR "framework$"
+    )
 )
 ```
 
 #### Phrase 3
 
-The general structure is *undernutrition/food supply + actions + humans*. For the topics `"protein deficiency"  OR "undernourish*" OR "under-nourish*" OR "undernutrition" OR "under-nutrition"` and `food supply` there was a considerable number of papers from animals and therefore they had to be combined with *human terms*. The human terms include generic terms signifying a work is about humans as well as some "vulnerable" groups (based on UN sources) considered relevant for this topic (<a id="Blanchard">[Blanchard et al., 2017](#f16)</a>; <a id="UNOHC">[Office of the High Commissioner, n.d.](#f17)</a>).
+The general structure is *undernutrition/nutritional value + actions + humans*. For the topics `"protein deficiency"  OR "undernourish*" OR "under-nourish*" OR "undernutrition" OR "under-nutrition"` there was a considerable number of papers from animals and therefore they had to be combined with *human terms*. The human terms include generic terms signifying a work is about humans as well as some "vulnerable" groups (based on UN sources) considered relevant for this topic (<a id="Blanchard">[Blanchard et al., 2017](#f16)</a>; <a id="UNOHC">[Office of the High Commissioner, n.d.](#f17)</a>).
 
 ```py
 TS=
@@ -233,6 +230,15 @@ TS=
            OR "prevent*" OR "avoid*"
            OR "manag*" OR "treat*" OR "therapy" OR "therapies" OR "intervention$"
            OR "legislat*" OR "policy" OR "policies" OR "strateg*" OR "framework$"
+          )
+    )
+  OR
+    (
+      ("nutritional value" OR "nutrient content" OR "nutritional content")
+      NEAR/5
+          ("improv*" OR "enhanc*" OR "increas*" OR "strengthen" OR "better"
+          OR "ensur*" OR "guarantee" OR "secure" OR "securing" OR "maintain*"
+          OR "legislat*" OR "policy" OR "policies" OR "strateg*" OR "framework$"
           )
     )
   )

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -12,7 +12,7 @@ End hunger, achieve food security and improved nutrition and promote sustainable
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters, publication year = last 5 years): https://www.webofscience.com/wos/woscc/summary/0969ff8f-ca52-494b-bb44-a304810f5f92-a837ae09/relevance/1
+Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters, publication year = last 5 years): https://www.webofscience.com/wos/woscc/summary/d09f9ac7-bf55-4e60-a600-c78342841d3c-b76c21c2/relevance/1
 
 ## 2. General notes
 
@@ -1076,9 +1076,9 @@ TS=
 
 * Testing v1.2.2: Project group; see documentation https://doi.org/10.5281/zenodo.8386611
 
-* v1.3.0: Caroline S. Armitage (Aug-Sep 2023), minor review Eli Heldaas Seland.
+* v2.0.0: Caroline S. Armitage (Aug-Sep 2023), minor review Eli Heldaas Seland.
 
-Specialist input: Awaiting specialist input.
+Specialist input: Awaiting.
 
 ## 5. Footnotes
 

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -310,7 +310,7 @@ TS= (
                   OR "agricultur*" OR "farm*" OR "permaculture"
                   OR "cropping system$" OR "orchard$" OR "arable land$"
                   OR "pasture$" OR "pastoral*" OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-                  OR "aquaculture" OR "fisher*" OR "fish farm*"
+                  OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
                   )
                 OR
                   (
@@ -357,7 +357,7 @@ TS=
       OR "ecoagricultur*" OR "eco agricultur*" OR "permaculture"
       OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoral*"
       OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-      OR "aquaculture" OR "fish farm*"
+      OR "aquaculture" OR "fish farm*" OR "mariculture"
       OR
         (
           ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
@@ -411,7 +411,7 @@ TS=
       OR "ecoagricultur*" OR "eco agricultur*" OR "permaculture"
       OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoralist$"
       OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-      OR "aquaculture" OR "fisher*" OR "fish farm*"
+      OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
       OR "crop$" OR "cereal$" OR "rice" OR "wheat" OR "maize"
       OR "livestock" OR "cattle" OR "sheep" OR "poultry" OR "chicken$" OR "pig$" OR "goat$"
       OR
@@ -467,7 +467,7 @@ TS=
     OR "ecoagricultur*" OR "eco agricultur*" OR "permaculture"
     OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoralist$"
     OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-    OR "aquaculture" OR "fisher*" OR "fish farm*"
+    OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
     OR "crop$" OR "cereal$" OR "rice" OR "wheat" OR "maize"
     OR "livestock" OR "cattle" OR "sheep" OR "poultry" OR "chicken$" OR "pig$" OR "goat$"
     OR
@@ -544,7 +544,7 @@ TS=
     OR "farm*" OR "agricultur*" OR "smallhold*" OR "small hold*"
     OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoral*"
     OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-    OR "aquaculture" OR "fisher*" OR "fish farm*"
+    OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
     OR
       (
         ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
@@ -586,7 +586,7 @@ TS=
     OR "permaculture"
     OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoral*"
     OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-    OR "aquaculture" OR "fisher*" OR "fish farm*"
+    OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
     OR
       (
         ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
@@ -628,7 +628,7 @@ TS=
   OR "permaculture"
   OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoral*"
   OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-  OR "aquaculture" OR "fisher*" OR "fish farm*"
+  OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
   OR   
     (
       ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
@@ -763,7 +763,7 @@ TS=
             OR "smallhold*" OR "small hold*"
             OR "permaculture" OR "cropping system$" OR "orchard$"
             OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-            OR "aquaculture"
+            OR "aquaculture" OR "mariculture"
             OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
             OR "livestock" OR "poultry" OR "cattle" OR "sheep" OR "pig$" OR "goat$" OR "chicken$" OR "duck$" OR "buffalo*"      
             OR "landrace$" OR "wild relative$"
@@ -809,7 +809,7 @@ TS=
           OR "smallhold*" OR "small hold*"
           OR "permaculture" OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
           OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-          OR "aquaculture"
+          OR "aquaculture" OR "mariculture"
           OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
           OR "livestock" OR "poultry" OR "cattle" OR "sheep" OR "pig$" OR "goat$" OR "chicken$" OR "duck$" OR "buffalo*"     
           OR "landrace$" OR "wild relative$"
@@ -865,7 +865,7 @@ TS=
       OR "smallhold*" OR "small hold*"
       OR "permaculture" OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
       OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-      OR "aquaculture"
+      OR "aquaculture" OR "mariculture"
       OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
       OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
       OR "landrace$" OR "wild relative$"
@@ -897,7 +897,7 @@ TS =
         OR "smallhold*" OR "small hold*"
         OR "permaculture" OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
         OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-        OR "aquaculture"
+        OR "aquaculture" OR "mariculture"
         OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
         OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
         OR "landrace$" OR "wild relative$"
@@ -956,7 +956,7 @@ TS =
             OR
               (
                 ("infrastructure" OR "technolog*" OR "biotech*" OR "research" OR "science$" OR "innovation" OR "R&D")
-                NEAR/5 ("agricultur*" OR "smallhold*" OR "small hold*" OR "farm*" OR "irrigation" OR "agri food" OR "agrifood")
+                NEAR/5 ("agricultur*" OR "smallhold*" OR "small hold*" OR "farm*" OR "irrigation" OR "agri food" OR "agrifood" OR "aquaculture" OR "mariculture")
               )                  
             )
       )
@@ -1065,6 +1065,8 @@ TS=
 * v1.0.0 Caroline S. Armitage (Oct 2021-Oct 2022)
 
 * Internal review: Eli Heldaas Seland, Marta Lorenz (March 2022)
+
+* Revision after testing: Caroline S. Armitage (July 2023)
 
 Specialist input: Awaiting specialist input.
 

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -908,27 +908,26 @@ TS =
 >
 > 2.a.2 Total official flows (official development assistance plus other official flows) to the agriculture sector
 
-This target is interpreted to cover research about investment and international collaboration in rural infrastructure, agricultural research & technology, and gene banks in developing countries.
+This target is interpreted to cover research about investment and international collaboration in rural infrastructure, agricultural research & technology, and gene banks in developing countries. Investment/finance is kept broad - it is interpreted to cover international, private, public or individual investment/finance.
 
-This query consists of 1 phrase. The general structure is *investment/cooperation + rural infrastructure/technology*. Note that this phrase does not contain an action element as it was considered too difficult/restrictive.
+This query consists of 1 phrase. The general structure is *investment/cooperation + rural infrastructure/technology + LMICs*. Note that this phrase does not contain an action element as it was considered too difficult/restrictive. Various terms are specified for `invest*` and `financ*` instead of allowing free truncation - this is to avoid e.g. "investigation", "financial sector", "financial performance". `expenditure` and `spending` are combined as these are often used for individual farmers' expenses.
 
 ```py
 TS =
 (
       ("Agriculture Orientation Index for Government Expenditure$"
       OR
-        (
-          (
-            ("government" OR "public")
-            NEAR/3 ("expenditure" OR "invest*" OR "financ*" OR "spending")
-          )
+        ("investm*" OR "investing" OR "invest" OR "finance" OR "financial support" OR "financing" OR "funding"
         OR "ODA" OR "cooperation fund$" OR "development spending"
+        OR (("research" OR "governm*" OR "public" OR "sector") NEAR/3 ("expenditure" OR "spending"))
         OR
           (
-            ("international" OR "development" OR "foreign")
+            ("international" OR "development" OR "foreign" OR "global" OR "intercontinental"
+            OR "european" OR "asian" OR "africa*" OR "latin america*" OR "pacific"
+            )
             NEAR/3
                 ("cooperat*" OR "co-operat*" OR "collaborat*" OR "network$" OR "partnership$"
-                OR "aid" OR "assistance" OR "fund$" OR "funding" OR "financing" OR "finance" OR "grant$" OR "investment$" OR "financial support" OR "financial resources"
+                OR "aid" OR "assistance" OR "fund$" OR "grant$" OR "financial resources"
                 )
           )
         )
@@ -939,7 +938,7 @@ TS =
             OR
               (
                 ("infrastructure" OR "technolog*" OR "biotech*" OR "research" OR "science$" OR "innovation" OR "R&D")
-                NEAR/3 ("agricultur*" OR "smallhold*" OR "small hold*" OR "farm*" OR "irrigation" OR "agri food" OR "agrifood")
+                NEAR/5 ("agricultur*" OR "smallhold*" OR "small hold*" OR "farm*" OR "irrigation" OR "agri food" OR "agrifood")
               )                  
             )
       )

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -525,7 +525,9 @@ The general structure is *(ecoagriculture + action) OR (food production systems 
 
 `ecoagricultur*` is a relatively specialist term for ecology and agriculture and considered narrow enough to use alone.
 
-Other terms suggesting research about sustainable agriculture were combined with the agricultural terms. `agroecolog*` (agroecology, or the agroecological approach) is considered a relevant term for sustainable, being related to ecology and environmental stability as well as social and cultural dimensions (<a id="SFS">[One Planet network Sustainable Food Systems (SFS) Programme, 2020, p. 28](#f8)</a>). Other terms for practices/approaches that can be considered to contribute to "sustainable food production systems" were gathered from <a id="HLPE">[High Level Panel of Experts on Food Security and Nutrition (2019, Appendix 1 and p. 36)](#f14)</a>; some of these also are relevant for soil quality. Other terms from this source are included in other phrases: "sustainable intensification" is covered in phrase 1, "climate smart agriculture" in phrase 2. `organic` must be combined due to use in other contexts (e.g. soil organic matter, organic carbon).
+*Agricultural terms*: The standard terms used in other phrases are repeated here, but `"fodder" OR "animal feed" OR "fish feed"` are also added, as sustainable fodder research does not always use a term for agriculture.
+
+*Sustainbility terms*: `agroecolog*` (agroecology, or the agroecological approach) is considered a relevant term for sustainable, being related to ecology and environmental stability as well as social and cultural dimensions (<a id="SFS">[One Planet network Sustainable Food Systems (SFS) Programme, 2020, p. 28](#f8)</a>). Other terms for practices/approaches that can be considered to contribute to "sustainable food production systems" were gathered from <a id="HLPE">[High Level Panel of Experts on Food Security and Nutrition (2019, Appendix 1 and p. 36)](#f14)</a>; some of these also are relevant for soil quality. Other terms from this source are included in other phrases: "sustainable intensification" is covered in phrase 1, "climate smart agriculture" in phrase 2. `organic` must be combined due to use in other contexts (e.g. soil organic matter, organic carbon).
 
 ```py
 TS=
@@ -549,6 +551,7 @@ TS=
     OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoral*"
     OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
     OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
+    OR "fodder" OR "animal feed" OR "fish feed"
     OR
       (
         ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -551,7 +551,7 @@ TS=
     )
     NEAR/15
         (
-          ("sustainab*" OR "agroecolog*" OR "eco-friendly" OR "environmentally friendly" OR "ecosystem approach"
+          ("sustainab*" OR "agroecolog*" OR "eco-friendly" OR "environmentally friendly" OR "ecosystem approach" OR "ecosystem based"
           OR ("organic" NEAR/3 ("farm*" OR "agricultur*" OR "cultivation" OR "gardening" OR "production" OR "orchard$" OR "pasture$" OR "aquaculture"))
           OR "natural pest control" OR "natural pest management" OR "biological pest control" OR "intergrated pest management"
           OR "intercropping" OR "cover crop$" OR "crop rotation" OR "polyculture$" OR "permaculture"
@@ -572,7 +572,7 @@ TS=
 
 #### Phrase 5
 
-The general structure is *food production systems + ecosystems and soil + action*. This phrase covers "positives" (soil health, diversity, fertility etc.), phrase 6 covers "negatives" (loss, degradation etc.). Some terms are already covered in phrase 4 (e.g. reduced tillage).
+The general structure is *food production systems + ecosystems and soil + action*. This phrase covers "positives" (soil health, diversity, fertility etc.), phrase 6 covers "negatives" (loss, degradation etc.). Some terms are already covered in phrase 4 (e.g. reduced tillage). `ecosystem` is such a widely-used word, so it was combined with terms that indicate the work is about ecosystem health in light of agriculture. 
 
 ```py
 TS=
@@ -597,7 +597,8 @@ TS=
             (
               ("soil structure" OR "soil fertility" OR "soil health"
               OR ("quality" NEAR/5 ("soil" OR "land" OR "farmland"))
-              OR "biodiversity" OR "agrobiodiversity" OR "species diversity" OR "ecosystem$" OR "pollinator$"
+              OR "biodiversity" OR "agrobiodiversity" OR "species diversity" OR "pollinator$"
+              OR ("ecosystem$" NEAR/3 ("health*" OR "resilien*" OR "function*" OR "restor*" OR "quality" OR "stability" OR "impact$" OR "effect$" OR "affect*"))
               )
               NEAR/5
                 ("improv*" OR "restor*" OR "enhanc*" OR "strengthen*"
@@ -635,6 +636,7 @@ TS=
   NEAR/15
       (
         ("desertification"
+        OR "environmental impact$" OR "environmental footprint"
         OR
           ("soil$"
           NEAR/5
@@ -647,7 +649,7 @@ TS=
         OR
           (
             ("ecosystem$" OR "biodiversity" OR "land" OR "species" OR "pollinator$")
-            NEAR/5 ("loss" OR "degradation" OR "depletion")
+            NEAR/5 ("loss" OR "degradation" OR "depletion" OR "vulnerab*")
           )
         )
         NEAR/5

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -269,7 +269,9 @@ This query consists of 1 phrase. The basic structure is *productivity/access etc
 ```py
 TS= (
       (
-        ("intensification" NEAR/5 ("smallhold*" OR "sustainable" OR "agroecolog*" OR "ecolog*"))  
+          ("intensification" 
+            NEAR/5 ("smallhold*" OR "small farm*" OR "family farm*" OR "family run farm*" OR "family owned farm*" OR "sustainable" OR "agroecolog*" OR "ecolog*")
+          )  
         OR
           (
             ("production" OR "productivity" OR "yield$" OR "agricultural output$" OR "farm output$"
@@ -296,9 +298,9 @@ TS= (
                 OR "policy" OR "policies" OR "strateg*" OR "framework$" OR "governance" OR "legislat*" OR "regulate"
                 )
           )
-        )
-        AND
-          ("smallhold*" OR "family farm*" OR "family run farm*" OR "family owned farm*" OR "home gardening"
+      )
+      AND
+          ("smallhold*" OR "small farm*" OR "family farm*" OR "family run farm*" OR "family owned farm*" OR "home gardening"
           OR
             (
               ("small-scale" OR "indigenous" OR "homestead*" OR "subsistence")
@@ -315,8 +317,7 @@ TS= (
                     ("crop$" OR "produce" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
                     OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
                     )
-                    NEAR/5
-                        ("production" OR "producer$" OR "grower$" OR "herder$" OR "herding")
+                    NEAR/5 ("production" OR "producer$" OR "grower$" OR "herder$" OR "herding")
                   )
                 )
             )

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -934,7 +934,7 @@ TS =
 
 This target is interpreted to cover research about investment and international collaboration in rural infrastructure, agricultural research & technology, and gene banks in developing countries. Investment/finance is kept broad - it is interpreted to cover international, private, public or individual investment/finance.
 
-This query consists of 1 phrase. The general structure is *investment/cooperation + rural infrastructure/technology + LMICs*. Note that this phrase does not contain an action element as it was considered too difficult/restrictive. Various terms are specified for `invest*` and `financ*` instead of allowing free truncation - this is to avoid e.g. "investigation", "financial sector", "financial performance". `expenditure` and `spending` are combined as these are often used for individual farmers' expenses.
+This query consists of 1 phrase. The general structure is *investment/cooperation + rural/agricultural infrastructure/technology + LMICs*. Note that this phrase does not contain an action element as it was considered too difficult/restrictive. Various terms are specified for `invest*` and `financ*` instead of allowing free truncation - this is to avoid e.g. "investigation", "financial sector", "financial performance". `expenditure` and `spending` are combined as these are often used for individual farmers' expenses.  `rural development` is limited with *agricultural terms* as it is wider than our interpretation (e.g. it can refer to poverty alleviation in rural areas, whereas we interpret this target to be focused on agriculture). 
 
 ```py
 TS =
@@ -944,6 +944,7 @@ TS =
         ("investm*" OR "investing" OR "invest" OR "finance" OR "financial support" OR "financing" OR "funding"
         OR "ODA" OR "cooperation fund$" OR "development spending"
         OR (("research" OR "governm*" OR "public" OR "sector") NEAR/3 ("expenditure" OR "spending"))
+        OR "international development"
         OR
           (
             ("international" OR "development" OR "foreign" OR "global" OR "intercontinental"
@@ -956,13 +957,15 @@ TS =
           )
         )
         NEAR/15
-            ("rural infrastructure"
+            ("rural infrastructure" OR "rural tech*" 
+            OR ("rural development" AND ("agri*" OR "agro*" OR "smallhold*" OR "farm*"))
+            OR "agricultur* development" OR "development of agriculture"
             OR "agronom*" OR "agroecolog*" OR "agro ecolog*" OR "agricultural sector"
             OR "plant bank$" OR "seed bank$" OR "gene bank$" OR "genebank$" OR "germplasm bank$" OR "cryobank$"
             OR
               (
                 ("infrastructure" OR "technolog*" OR "biotech*" OR "research" OR "science$" OR "innovation" OR "R&D")
-                NEAR/5 ("agricultur*" OR "smallhold*" OR "small hold*" OR "farm*" OR "irrigation" OR "agri food" OR "agrifood" OR "aquaculture" OR "mariculture")
+                NEAR/5 ("agricultur*" OR "smallhold*" OR "small hold*" OR "farm*" OR "irrigation" OR "agri food" OR "agrifood" OR "agrofood" OR "aquaculture" OR "mariculture")
               )                  
             )
       )

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -794,7 +794,7 @@ For the *gene bank/ex situ* terms, `cryoconservation` and `cryopreservation` are
 TS=
 (
   (
-      ("cryoconservation" OR "gene bank" OR "genebank" OR "germplasm bank" OR "cryobank"
+      ("cryoconservation" OR "gene banks" OR "genebanks" OR "germplasm banks" OR "cryobanks"
       OR
         (
           ("plant bank$" OR "seed bank$"

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -681,10 +681,13 @@ The general structure is *agricultural diversity/landraces/local breeds + action
 
 Conserving wild relatives and traditional varieties is considered maintaining genetic diversity. `agrobiodiversity` is wider than only the species used in agriculture - it covers also the non-harvested species that support production and agro-ecosystems (e.g. pollinators, soil-organisms) (<a id="FAO2004">[FAO, 2004](#f10)</a>). It is considered relevant and included, as agrobiodiversity looks at the whole system (i.e. supporting diversity AND agricultural diversity). `conserv*` will cover e.g. conservation breeding, on-farm conservation etc. Note that `pigs` are excluded from the species list due to a large number of results about wild pig hunting in relation to their effect on agricultural land. 
 
+The use of `NEAR/1` is due to that this becomes very noisy when the distance is increased. 
+
 ```py
 TS=
 (
-    ("agricultural diversity" OR "agricultural biodiversity" OR "agrobiodiversity"
+    ("plant genetic resource$" OR "animal genetic resource$"
+    OR "agricultural diversity" OR "agricultural biodiversity" OR "agrobiodiversity"
     OR "landrace$" OR "wild relative$"
     OR  
       (
@@ -695,7 +698,6 @@ TS=
           OR "livestock" OR "poultry" OR "cattle" OR "sheep" OR "goat$" OR "chicken$" OR "duck$" OR "buffalo*"
           )
       )
-    OR "plant genetic resource$" OR "animal genetic resource$"
     )
     NEAR/5
         ("maintain*" OR "conserv*" OR "preserv*" OR "protect*"
@@ -728,25 +730,28 @@ TS=
         ("increase genetic diversity" OR "improve genetic diversity"
         OR
           (       
-             ("genetic diversity" OR "genetic resource$")
+             ("genetic resource$"
+             OR ("genetic" NEAR/2 "diversity")
+             )
              NEAR/10
                   ("maintain*" OR "conserv*" OR "preserv*" OR "protect*" OR "secure" OR "securing"
                   OR
-                      (
-                        ("loss" OR "extinction" OR "declin*" OR "disappear*")
-                        NEAR/5
+                    (
+                      ("loss" OR "extinction" OR "declin*" OR "disappear*")
+                      NEAR/5
                           ("decreas*" OR "minimi*" OR "reduc*" OR "limit$" OR "mitigat*"
                           OR "lowering" OR "lower$" OR "lowered" OR "combat*"
                           OR "stop*" OR "end" OR "ending" OR "halt"
                           OR "avoid*" OR "prevent*"
                           )
-                      )
+                    )
                   )
           )
         )
         NEAR/15
-            ("agricultur*" OR "domestic*" OR "farming" OR "farm$" OR "farmer$" OR "cultiva*" OR "permaculture"
-            OR "cropping system$" OR "orchard$"
+            ("agricultur*" OR "domestic*" OR "farming" OR "farmed" OR "farm$" OR "farmer$" OR "cultiva*" 
+            OR "smallhold*" OR "small hold*"
+            OR "permaculture" OR "cropping system$" OR "orchard$"
             OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
             OR "aquaculture"
             OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
@@ -773,11 +778,11 @@ For the *gene bank/ex situ* terms, `cryoconservation` and `cryopreservation` are
 TS=
 (
   (
-      ("cryoconservation"
+      ("cryoconservation" OR "gene bank" OR "genebank" OR "germplasm bank" OR "cryobank"
       OR
         (
           ("plant bank$" OR "seed bank$"
-          OR "gene bank$" OR "genebank$" OR "germplasm bank$" OR "cryobank$"
+          OR "gene bank" OR "genebank" OR "germplasm bank" OR "cryobank"
           OR "ex situ" OR "cryopreserv*"
           )
           NEAR/15
@@ -790,8 +795,9 @@ TS=
         )
       )  
       NEAR/15
-          ("agricultur*" OR "farming" OR "farm$" OR "farmer$" OR "cultiva*" OR "permaculture"
-          OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
+          ("agricultur*" OR "farming" OR "farmed" OR "farm$" OR "farmer$" OR "cultiva*" 
+          OR "smallhold*" OR "small hold*"
+          OR "permaculture" OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
           OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
           OR "aquaculture"
           OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
@@ -833,7 +839,7 @@ TS=
         OR "material transfer agreement$" OR "informed consent"
         OR
           (
-            ("sharing" OR "equitab*" OR "equal" OR "fair" OR "access" OR "accessing" OR "accessib*" OR "right$")
+            ("sharing" OR "equitab*" OR "equal" OR "fair" OR "access" OR "accessing" OR "accessib*" OR "availability" OR "right$")
             NEAR/5
                 ("improv*" OR "increase" OR "increasing" OR "enhanc*" OR "promot*" OR "stimulat*" OR "encourag*" OR "secure" OR "securing"
                 OR "better" OR "strengthen*" OR "empower" OR "empowering"
@@ -845,8 +851,9 @@ TS=
   )    
   AND
       ("food"
-      OR "agricultur*" OR "domestic*" OR "farming" OR "farm$" OR "farmer$" OR "cultivar$" OR "permaculture"
-      OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
+      OR "agricultur*" OR "domestic*" OR "farming" OR "farmed" OR "farm$" OR "farmer$" OR "cultivar$" 
+      OR "smallhold*" OR "small hold*"
+      OR "permaculture" OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
       OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
       OR "aquaculture"
       OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
@@ -876,8 +883,9 @@ TS =
     )
     AND
         ("food"
-        OR "agricultur*" OR "domestic*" OR "farming" OR "farm$" OR "farmer$" OR "cultiva*" OR "permaculture"
-        OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
+        OR "agricultur*" OR "domestic*" OR "farming" OR "farmed" OR "farm$" OR "farmer$" OR "cultiva*" 
+        OR "smallhold*" OR "small hold*"
+        OR "permaculture" OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
         OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
         OR "aquaculture"
         OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -406,7 +406,7 @@ The basic structure of phrase 2 is *food production systems + resilience/vulnera
 
 In the *food production system* terms, production systems and species are included (i.e. species are split from production where possible so that both resilience for the species and the production system will be covered). Some species remain linked to production to avoid irrelevant results (e.g. vegetable intake and psychological resilience). `pastoral*` is limited in this phrase, as it finds results from other uses (pastoral care, religion studies).
 
-In the *resilience* terms, `climate smart agriculture` is a term used for an approach specifically addressing climate change.
+In the *resilience* terms, `climate smart agriculture` is a term used for an approach specifically addressing climate change. `risk reduction` and `disaster reduction` are used instead of acccing `reduc*` to the NEAR combination because there are many works about risks that are not disasters (e.g. reducing health risks of chemicals on farms).
 
 ```py
 TS=
@@ -431,7 +431,7 @@ TS=
             (
               ("climate smart agriculture" OR "resilien*"
               OR (("disaster$" OR "risk$") NEAR/3 ("plan*" OR "strateg*" OR "relief" OR "manag*" OR "program*"))
-              OR "risk reduction"
+              OR "risk reduction" OR "diaster reduction"
               )
               NEAR/5
                   ("adopt*" OR "apply" OR "implement*" OR "establish*" OR "build*" OR "create" OR "creating"

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -80,7 +80,7 @@ TS=
 
 #### Phrase 2
 
-The general structure is *food access/safety/nutrition + action*. `food` should cover mechanisms such as food banks, food stamps, food credits, and descriptions such as good quality food etc. Some specific food assistance terms are also included, as these focus on ensuring that people have access to food. Here we are including `food sovereignty` as it encompasses the ideas of access to safe, adequate and nutritious food, so is included here.
+The general structure is *food access/safety/nutrition + action*. `food` (combined with *access* etc.) should cover mechanisms such as food banks, food stamps, food credits, and phrases such as "access to nutritious food". Some specific food assistance terms are also included, as these focus on ensuring that people have access to food. Here we are including `food sovereignty` as it encompasses the ideas of access to safe, adequate and nutritious food, so is included here.
 
 ```py
 TS=

--- a/SDG02_query_action_WoS.md
+++ b/SDG02_query_action_WoS.md
@@ -46,7 +46,7 @@ This target is interpreted to cover research about
 * Improving access/right to food and food safety (phrase 2)
 * Improving food supplies and food supply chains (phrase 3)
 
-Some of these topics may partially overlap with 2.2. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nuritional *security*). Research topics such as nutritional security or free school meals may cover both areas (i.e. address that people have enough food, and that it is of good nutritional quality).
+Some of these topics may partially overlap with 2.2. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nuritional *security*). Research topics such as nutritional security, free school meals and undernutrition may cover both areas (i.e. address that people have enough food, and that it is of sufficient nutritional quality).
 
 It consists of 3 phrases. Phrase 3 uses terms which need to be combined with human terms.
 
@@ -54,7 +54,7 @@ It consists of 3 phrases. Phrase 3 uses terms which need to be combined with hum
 
 The general structure is *hunger/food insecurity + action*
 
-Hunger is used in phrases (`ending hunger`, `world hunger`) to prevent finding results that are mostly medical/physiological. `feast and famine` refers to bioreactors/selective pressure in microbial cultures (not relevant). `Underfeeding` and `starvation` removed as seem to be used mostly in a medical/physiology context, rather than related to food security/supply.
+Hunger is used in phrases (`ending hunger`, `world hunger`) to prevent finding results that are mostly medical/physiological. `feast and famine` refers to bioreactors/selective pressure in microbial cultures (not relevant). `Underfeeding` and `starvation` removed as seem to be used mostly in a medical/physiology context, rather than related to food security/supply. `undernourishment` is used here as it is soley about meeting energy requirements from food (i.e. hunger), while wider terms such as "malnourishment" may refer also to the nutrient balance.
 
 ```py
 TS=
@@ -62,7 +62,7 @@ TS=
   (
     ("end hunger" OR "ending hunger" OR "ends hunger" 
     OR "world hunger" OR "child* hunger"
-    OR "hunger and poverty" OR "poverty and hunger" OR "famine$"
+    OR "hunger and poverty" OR "poverty and hunger" OR "famine$" OR "undernourishment"
     OR "food insecurity" OR "nutritional insecurity"
     )
     NEAR/5
@@ -139,7 +139,7 @@ This target is interpreted to cover research about
 - improving the nutritional quality of food
 - reducing malnutrition, and improving nutritional status for all people (including elements specific to children, girls, the elderly and pregnant women). Malnutrition includes both underweight and overweight (<a id="WHOmalnut">[WHO, 2021](#f4)</a>); this WHO factsheet was used to add terms, including specific micronutrients of worldwide importance (iodine, iron, vitamin A).
 
-Some of these topics partially overlap with 2.1, which covers access to food/food insecurity. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nuritional *security*). Research topics such as nutritional security or free school meals may cover both areas (i.e. address that people have enough food, and that it is of good nutritional quality).
+Some of these topics partially overlap with 2.1, which covers access to food/food insecurity. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nuritional *security*). Research topics such as nutritional security, free school meals and undernutrition may cover both areas (i.e. address that people have enough food, and that it is of sufficient nutritional quality).
 
 This query consists of 3 phrases. Phrase 3 is for terms which need to be combined with human terms.
 

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -736,27 +736,26 @@ TS =
 >
 > 2.a.2 Total official flows (official development assistance plus other official flows) to the agriculture sector
 
-This target is interpreted to cover research about investment and international collaboration in rural infrastructure, agricultural research & technology, and gene banks in developing countries.
+This target is interpreted to cover research about investment and international collaboration in rural infrastructure, agricultural research & technology, and gene banks in developing countries. Investment/finance is kept broad - it is interpreted to cover international, private, public or individual investment/finance.
 
-This query consists of 1 phrase. The elements of the phrase are: *investment/cooperation + rural infrastructure/technology*.
+This query consists of 1 phrase. The elements of the phrase are: *investment/cooperation + rural infrastructure/technology + LMICs*. Various terms are specified for `invest*` and `financ*` instead of allowing free truncation - this is to avoid e.g. "investigation", "financial sector", "financial performance". `expenditure` and `spending` are combined as these are often used for individual farmers' expenses.
 
 ```py
 TS =
 (
       ("Agriculture Orientation Index for Government Expenditure$"
       OR
-        (
-          (
-            ("government" OR "public")
-            NEAR/3 ("expenditure" OR "invest*" OR "financ*" OR "spending")
-          )
+        ("investm*" OR "investing" OR "invest" OR "finance" OR "financial support" OR "financing" OR "funding"
         OR "ODA" OR "cooperation fund$" OR "development spending"
+        OR (("research" OR "governm*" OR "public" OR "sector") NEAR/3 ("expenditure" OR "spending"))
         OR
           (
-            ("international" OR "development" OR "foreign")
+            ("international" OR "development" OR "foreign" OR "intercontinental"
+            OR "european" OR "asian" OR "africa*" OR "latin america*" OR "pacific"
+            )
             NEAR/3
                 ("cooperat*" OR "co-operat*" OR "collaborat*" OR "network$" OR "partnership$"
-                OR "aid" OR "assistance" OR "fund$" OR "funding" OR "financing" OR "finance" OR "grant$" OR "investment$" OR "financial support" OR "financial resources"
+                OR "aid" OR "assistance" OR "fund$" OR "grant$" OR "financial resources"
                 )
           )
         )
@@ -767,7 +766,7 @@ TS =
             OR
               (
                 ("infrastructure" OR "technolog*" OR "biotech*" OR "research" OR "science$" OR "innovation" OR "R&D")
-                NEAR/3 ("agricultur*" OR "smallhold*" OR "small hold*" OR "farm*" OR "irrigation" OR "agri food" OR "agrifood")
+                NEAR/5 ("agricultur*" OR "smallhold*" OR "small hold*" OR "farm*" OR "irrigation" OR "agri food" OR "agrifood")
               )                  
             )
       )

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -213,7 +213,7 @@ This query consists of 1 phrase. The elements of the phrase are: *productivity/a
 - Originally `"access*" OR "barrier$"` was combined with many other terms (e.g. access to credit, financial services, markets...) - however we have now cut this combination, as the target is so broad in what should be accessible. So now, papers talking about improving access to anything should be covered. A few irrelevant results are included due to the abstract including an "open access" publishing statement; and a couple from open access to e.g. satellite data. This is hard to exclude as we want "open access fisheries", for example. (Original combination: `"farmland$" OR "land" OR "resources" OR "financial service$" OR "banking" OR "microfinance" OR "credit" OR "microcredit" OR "insurance" OR "microinsurance" OR "market$" OR "marketing" OR "traders" OR "trade" OR "agricultur* input$" OR "farm input$" OR "water" OR "machinery" OR "equipment" OR "technology" OR "farm* experience" OR "information" OR "training" OR "equitab*" OR "inequitab*"`)
 
 ```py
-  TS=
+TS=
   (
     (
       ("intensification" NEAR/5 ("smallhold*" OR "small hold*" OR "small farm*" OR "family farm*" OR "family run farm*" OR "family owned farm*" OR "sustainable" OR "agroecolog*" OR "ecolog*"))  
@@ -244,8 +244,7 @@ This query consists of 1 phrase. The elements of the phrase are: *productivity/a
                     ("crop$" OR "produce" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
                     OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
                     )
-                    NEAR/5
-                        ("production" OR "producer$" OR "grower$" OR "herder$" OR "herding")
+                    NEAR/5 ("production" OR "producer$" OR "grower$" OR "herder$" OR "herding")
                   )
                 )
             )
@@ -415,7 +414,9 @@ The elements of the phrase are: *ecoagriculture OR (food production systems + su
 
 `ecoagricultur*` is a relatively specialist term for ecology and agriculture and considered narrow enough to use alone.
 
-Other terms suggesting research about sustainable agriculture were combined with the agricultural terms. `agroecolog*` (agroecology, or the agroecological approach) is considered a relevant term for sustainable, being related to ecology and environmental stability as well as social and cultural dimensions (<a id="SFS">[One Planet network Sustainable Food Systems (SFS) Programme, 2020, p. 28](#f8)</a>). Other terms for practices/approaches that can be considered to contribute to "sustainable food production systems" were gathered from <a id="HLPE">[High Level Panel of Experts on Food Security and Nutrition (2019, Appendix 1 and p. 36)](#f14)</a>; some of these also are relevant for soil quality. Other terms from this source are included in other phrases: "sustainable intensification" is covered in phrase 1, "climate smart agriculture" in phrase 2. `organic` must be combined due to use in other contexts (e.g. soil organic matter, organic carbon).
+*Agricultural terms*: The standard terms used in other phrases are repeated here, but `"fodder" OR "animal feed" OR "fish feed"` are also added, as sustainable fodder research does not always use a term for agriculture.
+
+*Sustainbility terms*: `agroecolog*` (agroecology, or the agroecological approach) is considered a relevant term for sustainable, being related to ecology and environmental stability as well as social and cultural dimensions (<a id="SFS">[One Planet network Sustainable Food Systems (SFS) Programme, 2020, p. 28](#f8)</a>). Other terms for practices/approaches that can be considered to contribute to "sustainable food production systems" were gathered from <a id="HLPE">[High Level Panel of Experts on Food Security and Nutrition (2019, Appendix 1 and p. 36)](#f14)</a>; some of these also are relevant for soil quality. Other terms from this source are included in other phrases: "sustainable intensification" is covered in phrase 1, "climate smart agriculture" in phrase 2. `organic` must be combined due to use in other contexts (e.g. soil organic matter, organic carbon).
 
 ```py
 TS=
@@ -431,6 +432,7 @@ TS=
     OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoral*"
     OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
     OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
+    OR "fodder" OR "animal feed" OR "fish feed"
     OR
       (
         ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -243,7 +243,7 @@ This query consists of 1 phrase. The elements of the phrase are: *productivity/a
                   )
                 OR
                   (
-                    ("crop$" OR "produce" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
+                    ("crop$" OR "produce" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
                     OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
                     )
                     NEAR/5
@@ -290,14 +290,14 @@ TS=
       OR "aquaculture" OR "fish farm*" OR "mariculture"
       OR
         (
-          ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
+          ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
           OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
           )
           NEAR/5 ("production" OR "producer$" OR "grower$" OR "herder$" OR "herding" OR "ranch*" OR "plantation$")
         )  
       OR
         (
-          ("crop$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses")
+          ("crop$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$")
           NEAR/5 "yield$"
         )     
       OR "grain yield$"
@@ -334,7 +334,7 @@ TS=
       OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoralist$"
       OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
       OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
-      OR "crop$" OR "cereal$" OR "rice" OR "wheat" OR "maize"
+      OR "crop$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "legume$"
       OR "livestock" OR "cattle" OR "sheep" OR "poultry" OR "chicken$" OR "pig$" OR "goat$"
       OR
         (
@@ -373,7 +373,7 @@ TS=
       OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoralist$"
       OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
       OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
-      OR "crop$" OR "cereal$" OR "rice" OR "wheat" OR "maize"
+      OR "crop$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "legume$"
       OR "livestock" OR "cattle" OR "sheep" OR "poultry" OR "chicken$" OR "pig$" OR "goat$"
       OR
         (
@@ -435,7 +435,7 @@ TS=
     OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
     OR
       (
-        ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
+        ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
         OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
         )
         NEAR/5 ("production" OR "producer$" OR "grower$" OR "herder$" OR "herding" OR "ranch*" OR "plantation$")
@@ -469,7 +469,7 @@ TS=
     OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
     OR
       (
-        ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
+        ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
         OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
         )
         NEAR/5 ("production" OR "producer$" OR "grower$" OR "herder$" OR "herding" OR "ranch*" OR "plantation$")
@@ -502,7 +502,7 @@ TS=
   OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
   OR
     (
-      ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
+      ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
       OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
       )
       NEAR/5 ("production" OR "producer$" OR "grower$" OR "herder$" OR "herding" OR "ranch*" OR "plantation$")
@@ -573,7 +573,7 @@ TS=
         (
           ("local" OR "traditional" OR "heirloom" OR "wild" OR "indigenous" OR "autochthonous")
           NEAR/1 
-            ("variet*" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
+            ("variet*" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
             OR "livestock" OR "poultry" OR "cattle" OR "sheep" OR "goat$" OR "chicken$" OR "duck$" OR "buffalo*")
         )
         AND "agricult*"
@@ -609,7 +609,7 @@ TS=
             OR "permaculture" OR "cropping system$" OR "orchard$"
             OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
             OR "aquaculture" OR "mariculture"
-            OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
+            OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
             OR "livestock" OR "poultry" OR "cattle" OR "sheep" OR "pig$" OR "goat$" OR "chicken$" OR "duck$" OR "buffalo*"
             OR "landrace$" OR "wild relative$"
             OR
@@ -655,7 +655,7 @@ TS=
           OR "permaculture" OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
           OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
           OR "aquaculture" OR "mariculture"
-          OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
+          OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
           OR "livestock" OR "poultry" OR "cattle" OR "sheep" OR "pig$" OR "goat$" OR "chicken$" OR "duck$" OR "buffalo*"     
           OR "landrace$" OR "wild relative$"
           OR
@@ -702,7 +702,7 @@ TS=
       OR "permaculture" OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
       OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
       OR "aquaculture" OR "mariculture"
-      OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
+      OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
       OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
       OR "landrace$" OR "wild relative$"
       OR
@@ -734,7 +734,7 @@ TS =
         OR "permaculture" OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
         OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
         OR "aquaculture" OR "mariculture"
-        OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
+        OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
         OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
         OR "landrace$" OR "wild relative$"
         OR
@@ -851,7 +851,7 @@ TS=
   NEAR/15
       (
         ("trade" OR "trading" OR "market$" OR "export$" OR "import$")
-        NEAR/5 ("agricultur*" OR "agrifood" OR "food" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses")
+        NEAR/5 ("agricultur*" OR "agrifood" OR "food" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$")
       )
 )
 ```
@@ -877,7 +877,7 @@ TS=
         (
           ("price$" OR "market$")
           NEAR/5
-            ("agricultur*" OR "agrifood" OR "food" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "livestock")
+            ("agricultur*" OR "agrifood" OR "food" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$" OR "livestock")
         )
 )
 OR 
@@ -885,7 +885,7 @@ TS=
 (
   ("price$"
   NEAR/3
-    ("agricultur*" OR "agrifood" OR "food" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "livestock")
+    ("agricultur*" OR "agrifood" OR "food" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$" OR "livestock")
   ) 
   AND ("food market$" OR "agrifood market$" OR "agricultural market$" OR "commodity market$" OR "market information" OR "grain market$" OR "rice market$" OR "wheat market$")
 )

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -831,7 +831,7 @@ The elements of the phrase are: *export subsidies + agriculture/food*.
 TS=
 (
   ("export subsid*" OR "export credit$" OR "export financ*" OR "export competition" OR "export support$")
-  AND ("agricultur*" OR "agrifood" OR "food")
+  AND ("agricultur*" OR "agrifood" OR "food" OR "aquaculture" OR "mariculture")
 )
 ```
 
@@ -851,7 +851,7 @@ TS=
   NEAR/15
       (
         ("trade" OR "trading" OR "market$" OR "export$" OR "import$")
-        NEAR/5 ("agricultur*" OR "agrifood" OR "food" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$")
+        NEAR/5 ("agricultur*" OR "agrifood" OR "food" OR "aquaculture" OR "mariculture" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$")
       )
 )
 ```
@@ -875,7 +875,7 @@ TS=
         (
           ("price$" OR "market$")
           NEAR/5
-            ("agricultur*" OR "agrifood" OR "food" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$" OR "livestock")
+            ("agricultur*" OR "agrifood" OR "food" OR "aquaculture" OR "mariculture" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$" OR "livestock")
         )
 )
 OR 
@@ -883,7 +883,7 @@ TS=
 (
   ("price$"
   NEAR/3
-    ("agricultur*" OR "agrifood" OR "food" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$" OR "livestock")
+    ("agricultur*" OR "agrifood" OR "food" OR "aquaculture" OR "mariculture" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$" OR "livestock")
   ) 
   AND ("food market$" OR "agrifood market$" OR "agricultural market$" OR "commodity market$" OR "market information" OR "grain market$" OR "rice market$" OR "wheat market$")
 )

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -459,7 +459,7 @@ TS=
       )      
     )
     NEAR/15
-          ("soil conservation"
+          ("soil conservation" OR "soil improv*"
           OR "soil structure" OR "soil fertility" OR "soil health"
           OR ("quality" NEAR/5 ("soil" OR "land" OR "farmland"))
           OR "biodiversity" OR "agrobiodiversity" OR "species diversity" OR "ecosystem$" OR "pollinator$"

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -55,7 +55,7 @@ It consists of 3 phrases. Phrase 3 uses terms which need to be combined with hum
 
 The elements of the phrase are: *hunger/food insecurity*
 
-Hunger is used in phrases in this approach (`ending hunger`, `world hunger`) to prevent finding results that are mostly medical/physiological. `feast and famine` refers to bioreactors/selective pressure in microbial cultures (not relevant), and is used in a double NOT to avoid losing relevant results. `Underfeeding` and `starvation` removed as seem to be used mostly in a medical/physiology context, rather than related to food security/supply. `undernourishment` is used here as it is soley about meeting energy requirements from food (i.e. hunger), while wider terms such as "malnourishment" may refer also to the nutrient balance.
+Hunger is used in phrases in this approach (`ending hunger`, `world hunger`) to prevent finding results that are mostly medical/physiological. `feast and famine` refers to bioreactors/selective pressure in microbial cultures (not relevant). `Underfeeding` and `starvation` removed as seem to be used mostly in a medical/physiology context, rather than related to food security/supply. `undernourishment` is used here as it is soley about meeting energy requirements from food (i.e. hunger), while wider terms such as "malnourishment" may refer also to the nutrient balance.
 
 ```py
 TS=
@@ -71,7 +71,7 @@ TS=
 
 #### Phrase 2
 
-The elements of the phrase are: *food access/security/safety*. `food` (NEAR *access* terms) should cover mechanisms such as food banks, food stamps, food credits, and descriptions such as good quality food etc. Some specific food assistance terms are also included, as these focus on ensuring that people have access to food. `nutrition* quality` does find some results about animal feed, but a number of them connect their work to food security and reducing food loss, so it is safer not to remove this term. Here we are including `food sovereignty` as it encompasses the ideas of access to safe, adequate and nutritious food.
+The elements of the phrase are: *food access/security/safety*. `food` (NEAR *access* terms) should cover mechanisms such as food banks, food stamps, food credits, and descriptions such as good quality food etc. Some specific food assistance terms are also included, as these focus on ensuring that people have access to food. Here we are including `food sovereignty` as it encompasses the ideas of access to safe, adequate and nutritious food.
 
 ```py
 TS=
@@ -152,7 +152,7 @@ TS=
 
 The elements of the phrase are: *nutritional access/quality OR nutrition + specific groups*
 
-Research about the nutritional status of the groups mentioned in the target is included here, along with research about nutrition quality. `nutritio*` should cover terms such as "access to nutritional care". `baby` is not used as it only adds noise about "baby mustard".
+Research about the nutritional status of the groups mentioned in the target is included here, along with research about nutrition quality. `nutritio*` (combined with *access* etc.) should cover terms such as "access to nutritional care". `nutrition* quality` finds some results about animal feed, but a number of them connect their work to food security and reducing food loss, so it is safer to keep this term. `baby` is not used as it only adds noise about "baby mustard".
 
 ```py
 TS=

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -600,24 +600,24 @@ Terminology to do with breeding programmes could be included here, but we want r
 ```py
 TS=
 (
-        ("genetic resource$"
-        OR ("genetic" NEAR/2 "diversity")
+  ("genetic resource$"
+  OR ("genetic" NEAR/2 "diversity")
+  )
+  NEAR/15
+      ("agricultur*" OR "domestic*" OR "farming" OR "farmed" OR "farm$" OR "farmer$" OR "cultiva*"
+      OR "smallhold*" OR "small hold*"
+      OR "permaculture" OR "cropping system$" OR "orchard$"
+      OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
+      OR "aquaculture" OR "mariculture"
+      OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
+      OR "livestock" OR "poultry" OR "cattle" OR "sheep" OR "pig$" OR "goat$" OR "chicken$" OR "duck$" OR "buffalo*"
+      OR "landrace$" OR "wild relative$"
+      OR
+        (
+          ("local*" OR "traditional" OR "heirloom" OR "wild" OR "indigenous" OR "autochthonous")
+          NEAR/3 ("breed$" OR "variet*" OR "cultivar$")
         )
-        NEAR/15
-            ("agricultur*" OR "domestic*" OR "farming" OR "farmed" OR "farm$" OR "farmer$" OR "cultiva*"
-            OR "smallhold*" OR "small hold*"
-            OR "permaculture" OR "cropping system$" OR "orchard$"
-            OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-            OR "aquaculture" OR "mariculture"
-            OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses" OR "legume$"
-            OR "livestock" OR "poultry" OR "cattle" OR "sheep" OR "pig$" OR "goat$" OR "chicken$" OR "duck$" OR "buffalo*"
-            OR "landrace$" OR "wild relative$"
-            OR
-              (
-                ("local*" OR "traditional" OR "heirloom" OR "wild" OR "indigenous" OR "autochthonous")
-                NEAR/3 ("breed$" OR "variet*" OR "cultivar$")
-              )
-            )
+      )
 )
 ```
 
@@ -675,7 +675,6 @@ The elements of the phrase are: *resources/knowledge + sharing/access + agricult
 For the *resource/knowledge* terms, `traditional NEAR knowledge` etc. will cover variations such as "traditional agricultural knowledge". The string is set up so that we do not have to define the benefits. Within the CBD/Nagoya protocol, benefits can be monetary/non-monetary (e.g. research results, royalties), related to using/commercialisation of genetic resources. "Using" includes research on genetics/biochemistry, development and biotechnology. (<a id="Garforth">[Garforth, 2018, p.3](#f12)</a>).
 
 `access OR accessing OR accessib*` is used to prevent "accessions". `biopiracy` is the unfair exploitation of biological resources/traditional knowledge.
-
 
 ```py
 TS=

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -253,10 +253,10 @@ This query consists of 1 phrase. The elements of the phrase are: *productivity/a
 > 2.4.1 Proportion of agricultural area under productive and sustainable agriculture
 
 This target is interpreted to cover research about
-*  productivity of food production systems (phrase 1)
+* productivity of food production systems (phrase 1)
 * resilient food production systems/agricultural practices, including adaptation and preparedness of food production systems/species to climate change and disasters (phrases 2,3)
 * sustainable food production systems/practices (outside of resilience; phrase 4)
-* food production systems and soil quality/ecosystems (phrase 5,6)
+* food production systems and soil quality/ecosystem health (phrase 5,6)
 
 Increasing productivity of all food production systems (i.e. without reference to sustainable/resilient practices) was not considered relevant in v1. However, the SDG indicator metadata clearly classes increased productivity as part of sustainability. Thus, it is included now.
 > "Maintaining or improving the output over time relative to the area of land used is an important aspect in  sustainability  for  a  range  of  reasons.  [...]. In a broader sense, an increase in the level of  land  productivity  enables  higher  production  while  reducing  pressure  on  increasingly  scarce  land  resources,  commonly  linked  to  deforestation  and  associated  losses  of  ecosystem  services  and biodiversity." (<a id="SDGindmetadata">[Statistics Division, 2021b, Indicator 2.4.1](#f9)</a>).
@@ -425,7 +425,7 @@ TS=
       )      
     )
     NEAR/15
-        ("sustainab*" OR "agroecolog*" OR "eco-friendly" OR "environmentally friendly" OR "ecosystem approach"
+        ("sustainab*" OR "agroecolog*" OR "eco-friendly" OR "environmentally friendly" OR "ecosystem approach" OR "ecosystem based" 
         OR ("organic" NEAR/3 ("farm*" OR "agricultur*" OR "cultivation" OR "gardening" OR "production" OR "orchard$" OR "pasture$" OR "aquaculture"))
         OR "natural pest control" OR "natural pest management" OR "biological pest control" OR "intergrated pest management"
         OR "intercropping" OR "cover crop$" OR "crop rotation" OR "polyculture$" OR "permaculture"
@@ -439,7 +439,7 @@ TS=
 
 #### Phrase 5
 
-The elements of the phrase are: *food production systems + ecosystems and soil*. This phrase covers "positives" (soil health, diversity, fertility etc.), phrase 6 covers "negatives" (loss, degradation etc.). Some terms are already covered in phrase 4 (e.g. reduced tillage)
+The elements of the phrase are: *food production systems + ecosystems and soil*. This phrase covers mostly "positives" (soil health, diversity, fertility etc.), phrase 6 covers "negatives" (loss, degradation etc.). Some terms are already covered in phrase 4 (e.g. reduced tillage). `ecosystem` is such a widely-used word, so it was combined with terms that indicate the work is about ecosystem health in light of agriculture. 
 
 ```py
 TS=
@@ -462,7 +462,8 @@ TS=
           ("soil conservation" OR "soil improv*"
           OR "soil structure" OR "soil fertility" OR "soil health"
           OR ("quality" NEAR/5 ("soil" OR "land" OR "farmland"))
-          OR "biodiversity" OR "agrobiodiversity" OR "species diversity" OR "ecosystem$" OR "pollinator$"
+          OR "biodiversity" OR "agrobiodiversity" OR "species diversity" OR "pollinator$"
+          OR ("ecosystem$" NEAR/3 ("health*" OR "resilien*" OR "function*" OR "restor*" OR "quality" OR "stability" OR "impact$" OR "effect$" OR "affect*"))
           )     
 )
 ```
@@ -492,6 +493,7 @@ TS=
   )
   NEAR/15
       ("desertification"
+      OR "environmental impact$" OR "environmental footprint"
       OR
         ("soil$"
         NEAR/5
@@ -504,7 +506,7 @@ TS=
       OR
         (
           ("ecosystem$" OR "biodiversity" OR "land" OR "species" OR "pollinator$")
-          NEAR/5 ("loss" OR "degradation" OR "depletion")
+          NEAR/5 ("loss" OR "degradation" OR "depletion" OR "vulnerab*")
         )
       )
 )

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -768,49 +768,49 @@ This query consists of 1 phrase. The elements of the phrase are: *investment/coo
 ```py
 TS =
 (
-      ("Agriculture Orientation Index for Government Expenditure$"
-      OR
-        ("investm*" OR "investing" OR "invest" OR "finance" OR "financial support" OR "financing" OR "funding"
-        OR "ODA" OR "cooperation fund$" OR "development spending"
-        OR (("research" OR "governm*" OR "public" OR "sector") NEAR/3 ("expenditure" OR "spending"))
-        OR "international development"
+  ("Agriculture Orientation Index for Government Expenditure$"
+  OR
+    ("investm*" OR "investing" OR "invest" OR "finance" OR "financial support" OR "financing" OR "funding"
+    OR "ODA" OR "cooperation fund$" OR "development spending"
+    OR (("research" OR "governm*" OR "public" OR "sector") NEAR/3 ("expenditure" OR "spending"))
+    OR "international development"
+    OR
+      (
+        ("international" OR "development" OR "foreign" OR "intercontinental"
+        OR "european" OR "asian" OR "africa*" OR "latin america*" OR "pacific"
+        )
+        NEAR/3
+             ("cooperat*" OR "co-operat*" OR "collaborat*" OR "network$" OR "partnership$"
+            OR "aid" OR "assistance" OR "fund$" OR "grant$" OR "financial resources"
+            )
+      )
+    )
+    AND
+        ("rural infrastructure" OR "rural tech*"
+        OR ("rural development" AND ("agri*" OR "agro*" OR "smallhold*" OR "farm*"))
+        OR "agricultur* development" OR "development of agriculture"
+        OR "agronom*" OR "agroecolog*" OR "agro ecolog*" OR "agricultural sector"
+        OR "plant bank$" OR "seed bank$" OR "gene bank$" OR "genebank$" OR "germplasm bank$" OR "cryobank$"
         OR
           (
-            ("international" OR "development" OR "foreign" OR "intercontinental"
-            OR "european" OR "asian" OR "africa*" OR "latin america*" OR "pacific"
-            )
-            NEAR/3
-                ("cooperat*" OR "co-operat*" OR "collaborat*" OR "network$" OR "partnership$"
-                OR "aid" OR "assistance" OR "fund$" OR "grant$" OR "financial resources"
-                )
-          )
+            ("infrastructure" OR "technolog*" OR "biotech*" OR "research" OR "science$" OR "innovation" OR "R&D")
+            NEAR/5 ("agricultur*" OR "smallhold*" OR "small hold*" OR "farm*" OR "irrigation" OR "agri food" OR "agrifood" OR "agrofood" OR "aquaculture" OR "mariculture")
+          )                  
         )
-        AND
-            ("rural infrastructure" OR "rural tech*"
-            OR ("rural development" AND ("agri*" OR "agro*" OR "smallhold*" OR "farm*"))
-            OR "agricultur* development" OR "development of agriculture"
-            OR "agronom*" OR "agroecolog*" OR "agro ecolog*" OR "agricultural sector"
-            OR "plant bank$" OR "seed bank$" OR "gene bank$" OR "genebank$" OR "germplasm bank$" OR "cryobank$"
-            OR
-              (
-                ("infrastructure" OR "technolog*" OR "biotech*" OR "research" OR "science$" OR "innovation" OR "R&D")
-                NEAR/5 ("agricultur*" OR "smallhold*" OR "small hold*" OR "farm*" OR "irrigation" OR "agri food" OR "agrifood" OR "agrofood" OR "aquaculture" OR "mariculture")
-              )                  
-            )
-      )
-      AND
-      ("least developed countr*" OR "least developed nation$"
-      OR "developing countr*" OR "developing nation$" OR "developing states" OR "developing world"
-      OR "less developed countr*" OR "less developed nation$" OR "under developed countr*" OR "under developed nation$" OR "underdeveloped countr*" OR "underdeveloped nation$" OR "underserved countr*" OR "underserved nation$" OR "deprived countr*" OR "deprived nation$"
-      OR "middle income countr*" OR "middle income nation$"
-      OR "low income countr*" OR "low income nation$" OR "lower income countr*" OR "lower income nation$"
-      OR "poor countr*" OR "poor nation$" OR "poorer countr*" OR "poorer nation$"
-      OR "lmic" OR "lmics" OR "third world" OR "global south" OR "lami countr*" OR "transitional countr*" OR "emerging economies" OR "emerging nation$"
-      OR "Angola*" OR "Benin" OR "beninese" OR "Burkina Faso" OR "Burkina fasso" OR "burkinese" OR "burkinabe" OR "Burundi*" OR "Central African Republic" OR "Chad" OR "Comoros" OR "comoro islands" OR "iles comores" OR "Congo" OR "congolese" OR "Djibouti*" OR "Eritrea*" OR "Ethiopia*" OR "Gambia*" OR "Guinea" OR "Guinea-Bissau" OR "guinean" OR "Lesotho" OR "lesothan*" OR "Liberia*" OR "Madagasca*" OR "Malawi*" OR "Mali" OR "malian" OR "Mauritania*" OR "Mozambique" OR "mozambican$" OR "Niger" OR "Rwanda*" OR "Sao Tome and Principe" OR "Senegal*" OR "Sierra Leone*" OR "Somalia*" OR "South Sudan" OR "Sudan" OR "sudanese" OR "Togo" OR "togolese" OR "tongan" OR "Uganda*" OR "Tanzania*" OR "Zambia*" OR "Cambodia*" OR "Kiribati*" OR "Lao People’s democratic republic" OR "Laos" OR "Myanmar" OR "myanma" OR "Solomon islands" OR "Timor Leste" OR "Tuvalu*" OR "Vanuatu*" OR "Afghanistan" OR "afghan$" OR "Bangladesh*" OR "Bhutan*" OR "Nepal*" OR "Yemen*" OR "Haiti*"
-      OR  "Antigua and Barbuda" OR "Antigua & Barbuda" OR "antiguan$" OR "Bahamas" OR "Bahrain" OR "Barbados" OR "Belize" OR "Cabo Verde" OR "Cape Verde" OR "Comoros" OR "comoro islands" OR "iles comores" OR "Cuba" OR "cuban$" OR "Dominica*" OR "Dominican Republic" OR "Micronesia*" OR "Fiji" OR "fijian$" OR "Grenada*" OR "Guinea-Bissau" OR "Guyana*" OR "Haiti*" OR "Jamaica*" OR "Kiribati*" OR "Maldives" OR "maldivian$" OR "Marshall Islands" OR "Mauritius" OR "mauritian$" OR "Nauru*" OR "Palau*" OR "Papua New Guinea*" OR "Saint Kitts and Nevis" OR "st kitts and nevis" OR "Saint Lucia*" OR "St Lucia*" OR "Vincent and the Grenadines" OR "Vincent & the Grenadines" OR "Samoa*" OR "Sao Tome" OR "Seychelles" OR "seychellois*" OR "Singapore*" OR "Solomon Islands" OR "Surinam*" OR "Timor-Leste" OR "timorese" OR "Tonga*" OR "Trinidad and Tobago" OR "Trinidad & Tobago" OR "trinidadian$" OR "tobagonian$" OR "Tuvalu*" OR "Vanuatu*" OR "Anguilla*" OR "Aruba*" OR "Bermuda*" OR "Cayman Islands" OR "Northern Mariana$" OR "Cook Islands" OR "Curacao" OR "French Polynesia*" OR "Guadeloupe*" OR "Guam" OR "Martinique" OR "Montserrat" OR "New Caledonia*" OR "Niue" OR "Puerto Rico" OR "puerto rican" OR "Sint Maarten" OR "Turks and Caicos" OR "Turks & Caicos" OR "Virgin Islands"
-      OR "Afghanistan" OR "afghan*" OR "Armenia*" OR "Azerbaijan*" OR "Bhutan" OR "bhutanese" OR "Bolivia*" OR "Botswana*" OR "Burkina Faso" OR "Burundi" OR "Central African Republic" OR "Chad" OR "Eswatini" OR "eswantian" OR "Ethiopia*" OR "Kazakhstan*" OR "kazakh" OR "Kyrgyzstan" OR "Kyrgyz*" OR "kirghizia" OR "kirgizstan" OR "Lao People’s Democratic Republic" OR "Laos" OR "Lesotho" OR "Malawi" OR "malawian" OR "Mali" OR "Mongolia*" OR "Nepal*" OR "Niger" OR "North Macedonia" OR "Republic of Macedonia" OR "Paraguay" OR "Moldova*" OR "Rwanda$" OR "South Sudan" OR "sudanese" OR "Swaziland" OR "Tajikistan" OR "tadjikistan" OR "tajikistani$" OR "Turkmenistan" OR "Uganda*" OR "Uzbekistan" OR "uzbekistani$" OR "Zambia" OR "zambian$" OR "Zimbabwe*"
-      OR "albania*" OR "algeria*" OR "angola*" OR "argentina*" OR "azerbaijan*" OR "bahrain*" OR "belarus*" OR "byelarus*" OR "belorussia" OR "belize*" OR "honduras" OR "honduran" OR "dahomey" OR "bosnia*" OR "herzegovina*" OR "botswana*" OR "bechuanaland" OR "brazil*" OR "brasil*" OR "bulgaria*" OR "upper volta" OR "kampuchea" OR "khmer republic" OR "cameroon*" OR "cameroun" OR "ubangi shari" OR "chile*" OR "china" OR "chinese" OR "colombia*" OR "costa rica*" OR "cote d’ivoire" OR "cote divoire" OR "cote d ivoire" OR "ivory coast" OR "croatia*" OR "cyprus" OR "cypriot" OR "czech" OR "ecuador*" OR "egypt*" OR "united arab republic" OR "el salvador*" OR "estonia*" OR "eswatini" OR "swaziland" OR "swazi" OR "gabon" OR "gabonese" OR "gabonaise" OR "gambia*" OR "ghana*" OR "gibralta*" OR "greece" OR "greek" OR "honduras" OR "honduran$" OR "hungary" OR "hungarian$" OR "india" OR "indian$" OR "indonesia*" OR "iran" OR "iranian$" OR "iraq" OR "iraqi$" OR "isle of man" OR "jordan" OR "jordanian$" OR "kenya*" OR "korea*" OR "kosovo" OR "kosovan$" OR "latvia*" OR "lebanon" OR "lebanese" OR "libya*" OR "lithuania*" OR "macau" OR "macao" OR "macanese" OR "malagasy" OR "malaysia*" OR "malay federation" OR "malaya federation" OR "malta" OR "maltese" OR "mauritania" OR "mauritanian$" OR "mexico" OR "mexican$" OR "montenegr*" OR "morocco" OR "moroccan$" OR "namibia*" OR "netherlands antilles" OR "nicaragua*" OR "nigeria*" OR "oman" OR "omani$" OR "muscat" OR "pakistan*" OR "panama*" OR "papua new guinea*" OR "peru" OR "peruvian$" OR "philippine$" OR "philipine$" OR "phillipine$" OR "phillippine$" OR "filipino$" OR "filipina$" OR "poland" OR "polish" OR "portugal" OR "portugese" OR "romania*" OR "russia" OR "russian$" OR "polynesia*" OR "saudi arabia*" OR "serbia*" OR "slovakia*" OR "slovak republic" OR "slovenia*" OR "melanesia*" OR "south africa*" OR "sri lanka*" OR "dutch guiana" OR "netherlands guiana" OR "syria" OR "syrian$" OR "thailand" OR "thai" OR "tunisia*" OR "ukraine" OR "ukrainian$" OR "uruguay*" OR "venezuela*" OR "vietnam*" OR "west bank" OR "gaza" OR "palestine" OR "palestinian$" OR "yugoslavia*" OR "turkish" OR "turkey" OR "georgian*"
-      )
+  )
+  AND
+  ("least developed countr*" OR "least developed nation$"
+  OR "developing countr*" OR "developing nation$" OR "developing states" OR "developing world"
+  OR "less developed countr*" OR "less developed nation$" OR "under developed countr*" OR "under developed nation$" OR "underdeveloped countr*" OR "underdeveloped nation$" OR "underserved countr*" OR "underserved nation$" OR "deprived countr*" OR "deprived nation$"
+  OR "middle income countr*" OR "middle income nation$"
+  OR "low income countr*" OR "low income nation$" OR "lower income countr*" OR "lower income nation$"
+  OR "poor countr*" OR "poor nation$" OR "poorer countr*" OR "poorer nation$"
+  OR "lmic" OR "lmics" OR "third world" OR "global south" OR "lami countr*" OR "transitional countr*" OR "emerging economies" OR "emerging nation$"
+  OR "Angola*" OR "Benin" OR "beninese" OR "Burkina Faso" OR "Burkina fasso" OR "burkinese" OR "burkinabe" OR "Burundi*" OR "Central African Republic" OR "Chad" OR "Comoros" OR "comoro islands" OR "iles comores" OR "Congo" OR "congolese" OR "Djibouti*" OR "Eritrea*" OR "Ethiopia*" OR "Gambia*" OR "Guinea" OR "Guinea-Bissau" OR "guinean" OR "Lesotho" OR "lesothan*" OR "Liberia*" OR "Madagasca*" OR "Malawi*" OR "Mali" OR "malian" OR "Mauritania*" OR "Mozambique" OR "mozambican$" OR "Niger" OR "Rwanda*" OR "Sao Tome and Principe" OR "Senegal*" OR "Sierra Leone*" OR "Somalia*" OR "South Sudan" OR "Sudan" OR "sudanese" OR "Togo" OR "togolese" OR "tongan" OR "Uganda*" OR "Tanzania*" OR "Zambia*" OR "Cambodia*" OR "Kiribati*" OR "Lao People’s democratic republic" OR "Laos" OR "Myanmar" OR "myanma" OR "Solomon islands" OR "Timor Leste" OR "Tuvalu*" OR "Vanuatu*" OR "Afghanistan" OR "afghan$" OR "Bangladesh*" OR "Bhutan*" OR "Nepal*" OR "Yemen*" OR "Haiti*"
+  OR  "Antigua and Barbuda" OR "Antigua & Barbuda" OR "antiguan$" OR "Bahamas" OR "Bahrain" OR "Barbados" OR "Belize" OR "Cabo Verde" OR "Cape Verde" OR "Comoros" OR "comoro islands" OR "iles comores" OR "Cuba" OR "cuban$" OR "Dominica*" OR "Dominican Republic" OR "Micronesia*" OR "Fiji" OR "fijian$" OR "Grenada*" OR "Guinea-Bissau" OR "Guyana*" OR "Haiti*" OR "Jamaica*" OR "Kiribati*" OR "Maldives" OR "maldivian$" OR "Marshall Islands" OR "Mauritius" OR "mauritian$" OR "Nauru*" OR "Palau*" OR "Papua New Guinea*" OR "Saint Kitts and Nevis" OR "st kitts and nevis" OR "Saint Lucia*" OR "St Lucia*" OR "Vincent and the Grenadines" OR "Vincent & the Grenadines" OR "Samoa*" OR "Sao Tome" OR "Seychelles" OR "seychellois*" OR "Singapore*" OR "Solomon Islands" OR "Surinam*" OR "Timor-Leste" OR "timorese" OR "Tonga*" OR "Trinidad and Tobago" OR "Trinidad & Tobago" OR "trinidadian$" OR "tobagonian$" OR "Tuvalu*" OR "Vanuatu*" OR "Anguilla*" OR "Aruba*" OR "Bermuda*" OR "Cayman Islands" OR "Northern Mariana$" OR "Cook Islands" OR "Curacao" OR "French Polynesia*" OR "Guadeloupe*" OR "Guam" OR "Martinique" OR "Montserrat" OR "New Caledonia*" OR "Niue" OR "Puerto Rico" OR "puerto rican" OR "Sint Maarten" OR "Turks and Caicos" OR "Turks & Caicos" OR "Virgin Islands"
+  OR "Afghanistan" OR "afghan*" OR "Armenia*" OR "Azerbaijan*" OR "Bhutan" OR "bhutanese" OR "Bolivia*" OR "Botswana*" OR "Burkina Faso" OR "Burundi" OR "Central African Republic" OR "Chad" OR "Eswatini" OR "eswantian" OR "Ethiopia*" OR "Kazakhstan*" OR "kazakh" OR "Kyrgyzstan" OR "Kyrgyz*" OR "kirghizia" OR "kirgizstan" OR "Lao People’s Democratic Republic" OR "Laos" OR "Lesotho" OR "Malawi" OR "malawian" OR "Mali" OR "Mongolia*" OR "Nepal*" OR "Niger" OR "North Macedonia" OR "Republic of Macedonia" OR "Paraguay" OR "Moldova*" OR "Rwanda$" OR "South Sudan" OR "sudanese" OR "Swaziland" OR "Tajikistan" OR "tadjikistan" OR "tajikistani$" OR "Turkmenistan" OR "Uganda*" OR "Uzbekistan" OR "uzbekistani$" OR "Zambia" OR "zambian$" OR "Zimbabwe*"
+  OR "albania*" OR "algeria*" OR "angola*" OR "argentina*" OR "azerbaijan*" OR "bahrain*" OR "belarus*" OR "byelarus*" OR "belorussia" OR "belize*" OR "honduras" OR "honduran" OR "dahomey" OR "bosnia*" OR "herzegovina*" OR "botswana*" OR "bechuanaland" OR "brazil*" OR "brasil*" OR "bulgaria*" OR "upper volta" OR "kampuchea" OR "khmer republic" OR "cameroon*" OR "cameroun" OR "ubangi shari" OR "chile*" OR "china" OR "chinese" OR "colombia*" OR "costa rica*" OR "cote d’ivoire" OR "cote divoire" OR "cote d ivoire" OR "ivory coast" OR "croatia*" OR "cyprus" OR "cypriot" OR "czech" OR "ecuador*" OR "egypt*" OR "united arab republic" OR "el salvador*" OR "estonia*" OR "eswatini" OR "swaziland" OR "swazi" OR "gabon" OR "gabonese" OR "gabonaise" OR "gambia*" OR "ghana*" OR "gibralta*" OR "greece" OR "greek" OR "honduras" OR "honduran$" OR "hungary" OR "hungarian$" OR "india" OR "indian$" OR "indonesia*" OR "iran" OR "iranian$" OR "iraq" OR "iraqi$" OR "isle of man" OR "jordan" OR "jordanian$" OR "kenya*" OR "korea*" OR "kosovo" OR "kosovan$" OR "latvia*" OR "lebanon" OR "lebanese" OR "libya*" OR "lithuania*" OR "macau" OR "macao" OR "macanese" OR "malagasy" OR "malaysia*" OR "malay federation" OR "malaya federation" OR "malta" OR "maltese" OR "mauritania" OR "mauritanian$" OR "mexico" OR "mexican$" OR "montenegr*" OR "morocco" OR "moroccan$" OR "namibia*" OR "netherlands antilles" OR "nicaragua*" OR "nigeria*" OR "oman" OR "omani$" OR "muscat" OR "pakistan*" OR "panama*" OR "papua new guinea*" OR "peru" OR "peruvian$" OR "philippine$" OR "philipine$" OR "phillipine$" OR "phillippine$" OR "filipino$" OR "filipina$" OR "poland" OR "polish" OR "portugal" OR "portugese" OR "romania*" OR "russia" OR "russian$" OR "polynesia*" OR "saudi arabia*" OR "serbia*" OR "slovakia*" OR "slovak republic" OR "slovenia*" OR "melanesia*" OR "south africa*" OR "sri lanka*" OR "dutch guiana" OR "netherlands guiana" OR "syria" OR "syrian$" OR "thailand" OR "thai" OR "tunisia*" OR "ukraine" OR "ukrainian$" OR "uruguay*" OR "venezuela*" OR "vietnam*" OR "west bank" OR "gaza" OR "palestine" OR "palestinian$" OR "yugoslavia*" OR "turkish" OR "turkey" OR "georgian*"
+  )
 )
 
 ```

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -71,7 +71,7 @@ TS=
 
 #### Phrase 2
 
-The elements of the phrase are: *food access/security/safety*. `food` (NEAR *access* terms) should cover mechanisms such as food banks, food stamps, food credits, and descriptions such as good quality food etc. Some specific food assistance terms are also included, as these focus on ensuring that people have access to food. Here we are including `food sovereignty` as it encompasses the ideas of access to safe, adequate and nutritious food.
+The elements of the phrase are: *food access/security/safety*. `food` (combined with *access* etc.) should cover mechanisms such as food banks, food stamps, food credits, and phrases such as "access to nutritious food". Some specific food assistance terms are also included, as these focus on ensuring that people have access to food. Here we are including `food sovereignty` as it encompasses the ideas of access to safe, adequate and nutritious food.
 
 ```py
 TS=

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -823,7 +823,7 @@ This target is interpreted to cover research about subsidies (and equivalents), 
 
 This query consists of 2 phrases.
 
-#### Phrase 1:
+#### Phrase 1
 
 The elements of the phrase are: *export subsidies + agriculture/food*.
 
@@ -835,7 +835,7 @@ TS=
 )
 ```
 
-#### Phrase 2:
+#### Phrase 2
 
 The elements of the phrase are: *distortions + agricultural markets/exports/imports*. Specific animals are not included due to results about restrictions in trade due to outbreaks of disease.
 
@@ -863,8 +863,6 @@ TS=
 > 2.c.1 Indicator of food price anomalies
 
 This target is interpreted to cover research about food prices and markets, stable food prices, and stable food markets. The elements of the phrase are: *volatility/stability + agricultural markets/prices OR food prices + markets*.
-
-#### Phrase 1:
 
 ```py
 TS=

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -2,8 +2,6 @@
 
 End hunger, achieve food security and improved nutrition and promote sustainable agriculture.
 
-**Current status**: This string is currently being edited after testing.
-
 **Contents**
 
 1. Full query
@@ -14,7 +12,7 @@ End hunger, achieve food security and improved nutrition and promote sustainable
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters, publication year = last 5 years):
+Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters, publication year = last 5 years): https://www.webofscience.com/wos/woscc/summary/60d089aa-b5e3-47e5-bc1c-609481d45120-a8382a58/relevance/1
 
 ## 2. General notes
 

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -47,7 +47,7 @@ This target is interpreted to cover research about
 * Access/right to food, food security, and food safety (phrase 2)
 * Food supplies and food supply chains (phrase 3)
 
-Some of these topics may partially overlap with 2.2. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nutritional *security*). Research topics such as nutritional security, free school meals and undernutrition may cover both areas (i.e. address that people have enough food, and that it is of sufficient nutritional quality).
+Some of these topics may partially overlap with 2.2. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *value*); 2.1 is interpreted to focus on access-related issues (e.g. nutritional *security*). Research topics such as nutritional security, free school meals and undernutrition may cover both areas (i.e. address the issue of whether people have enough food, and whether it is of sufficient nutritional quality).
 
 It consists of 3 phrases. Phrase 3 uses terms which need to be combined with human terms.
 
@@ -116,7 +116,7 @@ This target is interpreted to cover research about
 - the nutritional quality of food
 - malnutrition, and the nutritional status for all people (including elements specific to children, girls, the elderly and pregnant women). Malnutrition includes both underweight and overweight (<a id="WHOmalnut">[WHO, 2021](#f4)</a>); this WHO factsheet was used to add terms, including specific micronutrients of worldwide importance (iodine, iron, vitamin A).
 
-Some of these topics partially overlap with 2.1, which covers access to food/food insecurity. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nutritional *security*). Research topics such as nutritional security, free school meals and undernutrition may cover both areas (i.e. address that people have enough food, and that it is of sufficient nutritional quality).
+Some of these topics partially overlap with 2.1, which covers access to food/food insecurity. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *value*); 2.1 is interpreted to focus on access-related issues (e.g. nutritional *security*). Research topics such as nutritional security, free school meals and undernutrition may cover both areas (i.e. address the issue of whether people have enough food, and whether it is of sufficient nutritional quality).
 
 This query consists of 3 phrases. Phrase 3 is for terms which need to be combined with human terms.
 

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -322,7 +322,7 @@ The elements of the phrase are: *food production systems + resilience/vulnerabil
 
 In the *food production system* terms, production systems and species are included (i.e. species are split from production where possible so that both resilience for the species and the production system will be covered). Some species remain linked to production to avoid irrelevant results (e.g. vegetable intake and psychological resilience). `pastoral*` is limited in this phrase, as it finds results from other uses (pastoral care, religion studies).
 
-In the *resilience* terms, `climate smart agriculture` is a term used for an approach specifically addressing climate change.
+In the *resilience* terms, `climate smart agriculture` is a term used for an approach specifically addressing climate change. `risk reduction` and `disaster reduction` are used instead of acccing `reduc*` to the NEAR combination because there are many works about risks that are not disasters (e.g. reducing health risks of chemicals on farms).
 
 ```py
 TS=
@@ -344,7 +344,7 @@ TS=
       )
       NEAR/15
             ("climate smart agriculture" OR "resilien*"
-            OR "risk reduction"
+            OR "risk reduction" OR "diaster reduction"
             OR (("disaster$" OR "risk$") NEAR/3 ("plan*" OR "strateg*" OR "relief" OR "manag*" OR "program*"))
             OR "vulnerability"
             )  

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -42,50 +42,54 @@ During editing of this string (2021), we have consulted two other sets of querie
 > 2.1.2 Prevalence of moderate or severe food insecurity in the population, based on the Food Insecurity Experience Scale (FIES)
 
 This target is interpreted to cover research about
-* Hunger/lack of food and food insecurity
-* Access/right to food, food supplies and food supply chains
-* Safety and nutritional value of food
+* Hunger (phrase 1)
+* Food insecurity (phrase 1)
+* Access/right to food, food security, and food safety (phrase 2)
+* Food supplies and food supply chains (phrase 3)
+
+Some of these topics may partially overlap with 2.2. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nuritional *security*). Research topics such as nutritional security or free school meals may cover both areas (i.e. address that people have enough food, and that it is of good nutritional quality).
 
 It consists of 3 phrases. Phrase 3 uses terms which need to be combined with human terms.
 
 #### Phrase 1
 
-The elements of the phrase are: *hunger*
+The elements of the phrase are: *hunger/food insecurity*
 
 Hunger is used in phrases in this approach (`ending hunger`, `world hunger`) to prevent finding results that are mostly medical/physiological. `feast and famine` refers to bioreactors/selective pressure in microbial cultures (not relevant), and is used in a double NOT to avoid losing relevant results. `Underfeeding` and `starvation` removed as seem to be used mostly in a medical/physiology context, rather than related to food security/supply.
 
 ```py
 TS=
 (
-  ("end hunger" OR "ending hunger" OR "ends hunger" OR "world hunger"
+  ("end hunger" OR "ending hunger" OR "ends hunger" 
+  OR "world hunger" OR "child* hunger"
   OR "hunger and poverty" OR "poverty and hunger" OR "famine$"
   OR "food insecurity" OR "nutritional insecurity"
   )
-  NOT (("feast and famine" OR "feast-famine") NOT ("end* hunger" OR "malnutrition"))    
+  NOT ("feast and famine" OR "feast-famine")    
 )
 ```
 
 #### Phrase 2
 
-The elements of the phrase are: *food access/safety/nutrition*. `food` should cover mechanisms such as food banks, food stamps, food credits, and descriptions such as good quality food etc. `nutrition* quality` does find some results about animal feed, but a number of them connect their work to food security, reducing food loss, so it is safer not to remove this term. Here we are including `food sovereignty` as it encompasses the ideas of access to safe, adequate and nutritious food, so is included here.
+The elements of the phrase are: *food access/security/safety*. `food` (NEAR *access* terms) should cover mechanisms such as food banks, food stamps, food credits, and descriptions such as good quality food etc. Some specific food assistance terms are also included, as these focus on ensuring that people have access to food. `nutrition* quality` does find some results about animal feed, but a number of them connect their work to food security and reducing food loss, so it is safer not to remove this term. Here we are including `food sovereignty` as it encompasses the ideas of access to safe, adequate and nutritious food.
 
 ```py
 TS=
 (
-  "right to food" OR "right to adequate food" OR "food sovereignty"
-  OR "nutrition* security" OR "nutrition* quality" OR "nutrition sensitive agriculture"
+  "right to food" OR "right to adequate food" OR "food sovereignty" OR "nutrition* security"
   OR ("food" NEAR/5 ("access" OR "safety" OR "unsafe" OR "secure" OR "security" OR "reliable" OR "reliability"))
+  OR "school feeding" OR "free school meals" OR "food stamp program*" OR "nutrition assistance" OR "food assistance"
 )
 ```   
 
 #### Phrase 3
 
-The elements of the phrase are: *food supply/nutrient content + humans*. This phrase covers improving food supply, and is combined with "human terms" to prevent biology/ecology results. The human terms include generic terms signifying a work is about humans as well as some "vulnerable" groups (based on UN sources) considered relevant for this topic (<a id="Blanchard">[Blanchard et al., 2017](#f16)</a>; <a id="UNOHC">[Office of the High Commissioner, n.d.](#f17)</a>).
+The elements of the phrase are: *food supply + humans*. This phrase covers improving food supply, and is combined with "human terms" to prevent biology/ecology results. The human terms include generic terms signifying a work is about humans as well as some "vulnerable" groups (based on UN sources) considered relevant for this topic (<a id="Blanchard">[Blanchard et al., 2017](#f16)</a>; <a id="UNOHC">[Office of the High Commissioner, n.d.](#f17)</a>).
 
 ```py
 TS=
  (
-    ("food supply" OR "nutritional value" OR "nutrient content" OR "nutritional content")  
+    ("food supply")  
     AND
         ("humans" OR "humanity" OR "human" OR "people" OR "person$"
         OR "children" OR "child" OR "under fives" OR "infant$" OR "toddler$" OR "babies" OR "teenager$" OR "adolescent$" OR "youth$" OR "girls" OR "boys"
@@ -108,7 +112,11 @@ TS=
 >
 > 2.2.3 Prevalence of anaemia in women aged 15 to 49 years, by pregnancy status (percentage)
 
-This target is interpreted to cover research about malnutrition and the nutritional status for all people (including elements specific to children, girls, the elderly and pregnant women). Malnutrition includes both underweight and overweight (<a id="WHOmalnut">[WHO, 2021](#f4)</a>); this WHO factsheet was used to add terms, including specific micronutrients of worldwide importance (iodine, iron, vitamin A).
+This target is interpreted to cover research about 
+- the nutritional quality of food
+- malnutrition, and the nutritional status for all people (including elements specific to children, girls, the elderly and pregnant women). Malnutrition includes both underweight and overweight (<a id="WHOmalnut">[WHO, 2021](#f4)</a>); this WHO factsheet was used to add terms, including specific micronutrients of worldwide importance (iodine, iron, vitamin A).
+
+Some of these topics partially overlap with 2.1, which covers access to food/food insecurity. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nuritional *security*). Research topics such as nutritional security or free school meals may cover both areas (i.e. address that people have enough food, and that it is of good nutritional quality).
 
 This query consists of 3 phrases. Phrase 3 is for terms which need to be combined with human terms.
 
@@ -127,8 +135,7 @@ TS=
   OR
     (
       ("deficien*" OR "inadequa*")
-      NEAR/3
-          ("nutritional" OR "dietary" OR "vitamin$" OR "micronutrient$" OR "iron" OR "iodine")
+      NEAR/3 ("nutritional" OR "dietary" OR "vitamin$" OR "micronutrient$" OR "iron" OR "iodine")
     )
   OR  
     (
@@ -145,7 +152,7 @@ TS=
 
 The elements of the phrase are: *nutritional access/quality OR nutrition + specific groups*
 
-Research about the nutritional status of the groups mentioned in the target is included here. `stability` is not used in combination with food/nutrition as there are results about nutritional stability in processed foods. `nutritio*` should cover terms such as "access to nutritional care". `baby` is not used as it only adds noise about "baby mustard".
+Research about the nutritional status of the groups mentioned in the target is included here, along with research about nutrition quality. `nutritio*` should cover terms such as "access to nutritional care". `baby` is not used as it only adds noise about "baby mustard".
 
 ```py
 TS=
@@ -155,24 +162,26 @@ TS=
   OR
     (
       ("nutritio*" OR "folate status" OR "micronutrient$")
-      NEAR/5
+      NEAR/15
           ("women" OR "mother$" OR "pregnancy"
           OR "child*" OR "under five$" OR "infant$" OR "toddler$" OR "girl$" OR "boy$" OR "babies" OR "perinatal"
           OR "old* persons" OR "old* people" OR "elderly" OR "older adult$"
           )
     )
+  OR ("nutrition*" AND ("school feeding" OR "free school meals" OR "food stamp program*" OR "food assistance"))
 )
 ```
 
 #### Phrase 3
 
-The elements of the phrase are: *undernutrition/food supply + humans*. For the topics `"protein deficiency"  OR "undernourish*" OR "under-nourish*" OR "undernutrition" OR "under-nutrition"` there was a considerable number of papers from animals and therefore they had to be combined with *human terms*. The human terms include generic terms signifying a work is about humans as well as some "vulnerable" groups (based on UN sources) considered relevant for this topic (<a id="Blanchard">[Blanchard et al., 2017](#f16)</a>; <a id="UNOHC">[Office of the High Commissioner, n.d.](#f17)</a>).
+The elements of the phrase are: *undernutrition/nutritional value + humans*. For the topics `"protein deficiency"  OR "undernourish*" OR "under-nourish*" OR "undernutrition" OR "under-nutrition"` there was a considerable number of papers from animals and therefore they had to be combined with *human terms*. The human terms include generic terms signifying a work is about humans as well as some "vulnerable" groups (based on UN sources) considered relevant for this topic (<a id="Blanchard">[Blanchard et al., 2017](#f16)</a>; <a id="UNOHC">[Office of the High Commissioner, n.d.](#f17)</a>).
 
 ```py
 TS=
 (
   ("protein deficiency"
   OR "undernourish*" OR "under-nourish*" OR "undernutrition" OR "under-nutrition"
+  OR "nutritional value" OR "nutrient content" OR "nutritional content"
   )
   AND
       ("humans" OR "humanity" OR "human" OR "people" OR "person$"

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -14,7 +14,7 @@ End hunger, achieve food security and improved nutrition and promote sustainable
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here:  (no filters, all years)
+Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters, publication year = last 5 years):
 
 ## 2. General notes
 
@@ -935,7 +935,9 @@ NOT
 
 * Internal review: Eli Heldaas Seland, Marta Lorenz (March 2022); Eli Heldaas Seland (minor review Oct 2022)
 
-* Revision after testing: Caroline S. Armitage (July 2023)
+* Testing v1.2.2: Project group; see documentation https://doi.org/10.5281/zenodo.8386611
+
+* v1.3.0: Caroline S. Armitage (Aug-Sep 2023), minor review Eli Heldaas Seland.
 
 Specialist input: Awaiting specialist input.
 

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -534,16 +534,18 @@ Conserving wild relatives and traditional varieties is considered maintaining ge
 
 `landraces` and `varieties` are treated slightly differently here than the other terms: `varieties`is combined with agriculture as "traditional varieties" could refer to varieties of language, art etc. Note that `pigs` are excluded from the species list due to a large number of results about wild pig hunting in relation to their effect on agricultural land. `landraces` is connected to diversity terms to try and avoid technical works on e.g. sperm motility which use landrace/landrace-cross species. 
 
+The use of `NEAR/1` is due to that this becomes very noisy when the distance is increased. 
+
 ```py
 TS=
 (
     "plant genetic resource$" OR "animal genetic resource$"
+    OR "agricultural diversity" OR "agricultural biodiversity" OR "agrobiodiversity"
     OR  
       (
         ("local*" OR "traditional" OR "heirloom" OR "wild" OR "indigenous" OR "autochthonous")
         NEAR/3 ("breed$" OR "cultivar$")
       )
-    OR "agricultural diversity" OR "agricultural biodiversity" OR "agrobiodiversity"
     OR  
       (
         (
@@ -576,11 +578,13 @@ Terminology to do with breeding programmes could be included here, but we want r
 ```py
 TS=
 (
-        ("genetic diversity" OR "genetic resource$")
+        ("genetic resource$"
+        OR ("genetic" NEAR/2 "diversity")
+        )
         NEAR/15
-            ("agricultur*" OR "domestic*" OR "farming" OR "farm$" OR "farmer$" OR "cultiva*" OR "permaculture"
+            ("agricultur*" OR "domestic*" OR "farming" OR "farmed" OR "farm$" OR "farmer$" OR "cultiva*"
             OR "smallhold*" OR "small hold*"
-            OR "cropping system$" OR "orchard$"
+            OR "permaculture" OR "cropping system$" OR "orchard$"
             OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
             OR "aquaculture"
             OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
@@ -599,7 +603,7 @@ TS=
 
 The elements of the phrase are: *gene banks/ex situ + diversity/protection/policy + agriculture*
 
-The *diversity/protection/policy* terms are included to help to filter out publications which mention genebanks that were used in research (i.e. samples were taken from...). They ensure that the work relates to conservation, genetic diversity, or gene bank policies in some way. Action terms are not used because multiple angles can be relevant - research about establishment of gene banks for maintaining diversity, research about farmers' use of gene banks, research about how best to store samples in gene banks, etc.
+The *diversity/protection/policy* terms are included to help to filter out publications which mention genebanks that were used in research (i.e. samples were taken from...). They ensure that the work relates to conservation, genetic diversity, or gene bank policies in some way. This is less of an issue for some of the *genebank* terms when used as plurals, and so these are included alone.
 
 For the *gene bank/ex situ* terms, `cryoconservation` and `cryopreservation` are included as in vitro methods of conservation of diversity (<a id="FAO2015">[Commission on Genetic Resources for Food and Agriculture Assessments, 2015](#f11)</a>). For the *agriculture terms*, `domestic*` was removed from this phrase as results were mostly about domestic cats. A `NOT` expression was added for `seed banks` as these can be both human storage of seeds but also natural seed banks in the soil.
 
@@ -607,11 +611,11 @@ For the *gene bank/ex situ* terms, `cryoconservation` and `cryopreservation` are
 TS=
 (
   (
-      ("cryoconservation"
+      ("cryoconservation" OR "genebanks" OR "gene banks" OR "germplasm banks" OR "cryobanks"
       OR
         (
           ("plant bank$" OR "seed bank$"
-          OR "gene bank$" OR "genebank$" OR "germplasm bank$" OR "cryobank$"
+          OR "gene bank" OR "genebank" OR "germplasm bank" OR "cryobank"
           OR "ex situ" OR "cryopreserv*"
           )
           NEAR/15
@@ -624,9 +628,9 @@ TS=
         )
       )  
       NEAR/15
-          ("agricultur*" OR "farming" OR "farm$" OR "farmer$" OR "cultiva*" OR "permaculture"
+          ("agricultur*" OR "farming" OR "farmed" OR "farm$" OR "farmer$" OR "cultiva*" 
           OR "smallhold*" OR "small hold*"
-          OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
+          OR "permaculture" OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
           OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
           OR "aquaculture"
           OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
@@ -666,14 +670,14 @@ TS=
         ("governance" OR "justice" OR "ownership"
         OR "biopiracy" OR "inequitable" OR "inequity"
         OR "material transfer agreement$" OR "informed consent"
-        OR "sharing" OR "equitab*" OR "equal" OR "fair" OR "access" OR "accessing" OR "accessib*" OR "right$"
+        OR "sharing" OR "equitab*" OR "equal" OR "fair" OR "access" OR "accessing" OR "accessib*" OR "availability" OR "right$"
         )
   )    
   AND
       ("food"
-      OR "agricultur*" OR "domestic*" OR "farming" OR "farm$" OR "farmer$" OR "cultivar$" OR "permaculture"
+      OR "agricultur*" OR "domestic*" OR "farming" OR "farmed" OR "farm$" OR "farmer$" OR "cultivar$"
       OR "smallhold*" OR "small hold*"
-      OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
+      OR "permaculture" OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
       OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
       OR "aquaculture"
       OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
@@ -703,9 +707,9 @@ TS =
     )
     AND
         ("food"
-        OR "agricultur*" OR "domestic*" OR "farming" OR "farm$" OR "farmer$" OR "cultiva*" OR "permaculture"
+        OR "agricultur*" OR "domestic*" OR "farming" OR "farmed" OR "farm$" OR "farmer$" OR "cultiva*"
         OR "smallhold*" OR "small hold*"
-        OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
+        OR "permaculture" OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
         OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
         OR "aquaculture"
         OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -220,7 +220,7 @@ This query consists of 1 phrase. The elements of the phrase are: *productivity/a
       OR "land grab*" OR "tenure insecurity"
       )
       AND
-          ("smallhold*" OR "family farm*" OR "family run farm*" OR "family owned farm*" OR "home gardening"
+          ("smallhold*" OR "small farm*" OR "family farm*" OR "family run farm*" OR "family owned farm*" OR "home gardening"
           OR
             (
               ("small-scale" OR "indigenous" OR "homestead*" OR "subsistence")
@@ -571,8 +571,7 @@ Terminology to do with breeding programmes could be included here, but we want r
 ```py
 TS=
 (
-        ("genetic diversity" OR "genetic resource$"
-        )
+        ("genetic diversity" OR "genetic resource$")
         NEAR/15
             ("agricultur*" OR "domestic*" OR "farming" OR "farm$" OR "farmer$" OR "cultiva*" OR "permaculture"
             OR "cropping system$" OR "orchard$"

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -794,7 +794,7 @@ TS =
 >
 > 2.b.1 Agricultural export subsidies
 
-This target is interpreted to cover research about export subsidies (and equivalents) for agricultural/food exports, and trade restrictions and distortions for world agricultural/food markets. A WTO agricultural export subsidy fact sheet (<a id="WTOexport">[Information and External Relations Division of the WTO Secretariat, n.d.](#f13)</a>) was used as a source of terms, where food aid is also a factor.
+This target is interpreted to cover research about subsidies (and equivalents), trade restrictions and distortions for world agricultural/food markets/trade. A WTO agricultural export subsidy fact sheet (<a id="WTOexport">[Information and External Relations Division of the WTO Secretariat, n.d.](#f13)</a>) was used as a source of terms, where food aid is also a factor.
 
 This query consists of 2 phrases.
 
@@ -812,19 +812,20 @@ TS=
 
 #### Phrase 2:
 
-The elements of the phrase are: *distortions + agricultural markets/exports*. Specific animals are not included due to results about restrictions in trade due to outbreaks of disease.
+The elements of the phrase are: *distortions + agricultural markets/exports/imports*. Specific animals are not included due to results about restrictions in trade due to outbreaks of disease.
 
 ```py
 TS=
 (
   ("distort*" OR "price-fixing" OR "dumping"
-  OR "trade restrict*" OR "Doha" OR "food aid"
+  OR "trade restrict*" OR "sanction$"
+  OR "Doha" OR "food aid"
   OR "state support*" OR "state financial support"
   OR "WTO dispute$"
   )
   NEAR/15
       (
-        ("trade" OR "trading" OR "market$" OR "export$")
+        ("trade" OR "trading" OR "market$" OR "export$" OR "import$")
         NEAR/5 ("agricultur*" OR "agrifood" OR "food" OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses")
       )
 )

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -2,7 +2,7 @@
 
 End hunger, achieve food security and improved nutrition and promote sustainable agriculture.
 
-**Current status**: This string is currently a finished version.
+**Current status**: This string is currently being edited after testing.
 
 **Contents**
 
@@ -14,7 +14,7 @@ End hunger, achieve food security and improved nutrition and promote sustainable
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here: https://www.webofscience.com/wos/woscc/summary/68a40973-0972-49f4-848b-cf9452aab0f3-55f01ea3/relevance/1 (no filters, all years)
+Results of the full search in its current state can be viewed on Web of Science by clicking here:  (no filters, all years)
 
 ## 2. General notes
 

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -47,7 +47,7 @@ This target is interpreted to cover research about
 * Access/right to food, food security, and food safety (phrase 2)
 * Food supplies and food supply chains (phrase 3)
 
-Some of these topics may partially overlap with 2.2. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nuritional *security*). Research topics such as nutritional security or free school meals may cover both areas (i.e. address that people have enough food, and that it is of good nutritional quality).
+Some of these topics may partially overlap with 2.2. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nuritional *security*). Research topics such as nutritional security, free school meals and undernutrition may cover both areas (i.e. address that people have enough food, and that it is of sufficient nutritional quality).
 
 It consists of 3 phrases. Phrase 3 uses terms which need to be combined with human terms.
 
@@ -55,14 +55,14 @@ It consists of 3 phrases. Phrase 3 uses terms which need to be combined with hum
 
 The elements of the phrase are: *hunger/food insecurity*
 
-Hunger is used in phrases in this approach (`ending hunger`, `world hunger`) to prevent finding results that are mostly medical/physiological. `feast and famine` refers to bioreactors/selective pressure in microbial cultures (not relevant), and is used in a double NOT to avoid losing relevant results. `Underfeeding` and `starvation` removed as seem to be used mostly in a medical/physiology context, rather than related to food security/supply.
+Hunger is used in phrases in this approach (`ending hunger`, `world hunger`) to prevent finding results that are mostly medical/physiological. `feast and famine` refers to bioreactors/selective pressure in microbial cultures (not relevant), and is used in a double NOT to avoid losing relevant results. `Underfeeding` and `starvation` removed as seem to be used mostly in a medical/physiology context, rather than related to food security/supply. `undernourishment` is used here as it is soley about meeting energy requirements from food (i.e. hunger), while wider terms such as "malnourishment" may refer also to the nutrient balance.
 
 ```py
 TS=
 (
   ("end hunger" OR "ending hunger" OR "ends hunger" 
   OR "world hunger" OR "child* hunger"
-  OR "hunger and poverty" OR "poverty and hunger" OR "famine$"
+  OR "hunger and poverty" OR "poverty and hunger" OR "famine$" OR "undernourishment"
   OR "food insecurity" OR "nutritional insecurity"
   )
   NOT ("feast and famine" OR "feast-famine")    
@@ -116,7 +116,7 @@ This target is interpreted to cover research about
 - the nutritional quality of food
 - malnutrition, and the nutritional status for all people (including elements specific to children, girls, the elderly and pregnant women). Malnutrition includes both underweight and overweight (<a id="WHOmalnut">[WHO, 2021](#f4)</a>); this WHO factsheet was used to add terms, including specific micronutrients of worldwide importance (iodine, iron, vitamin A).
 
-Some of these topics partially overlap with 2.1, which covers access to food/food insecurity. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nuritional *security*). Research topics such as nutritional security or free school meals may cover both areas (i.e. address that people have enough food, and that it is of good nutritional quality).
+Some of these topics partially overlap with 2.1, which covers access to food/food insecurity. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nuritional *security*). Research topics such as nutritional security, free school meals and undernutrition may cover both areas (i.e. address that people have enough food, and that it is of sufficient nutritional quality).
 
 This query consists of 3 phrases. Phrase 3 is for terms which need to be combined with human terms.
 

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -764,7 +764,7 @@ TS =
 
 This target is interpreted to cover research about investment and international collaboration in rural infrastructure, agricultural research & technology, and gene banks in developing countries. Investment/finance is kept broad - it is interpreted to cover international, private, public or individual investment/finance.
 
-This query consists of 1 phrase. The elements of the phrase are: *investment/cooperation + rural infrastructure/technology + LMICs*. Various terms are specified for `invest*` and `financ*` instead of allowing free truncation - this is to avoid e.g. "investigation", "financial sector", "financial performance". `expenditure` and `spending` are combined as these are often used for individual farmers' expenses.
+This query consists of 1 phrase. The elements of the phrase are: *investment/cooperation + rural/agricultural infrastructure/technology + LMICs*. Various terms are specified for `invest*` and `financ*` instead of allowing free truncation - this is to avoid e.g. "investigation", "financial sector", "financial performance". `expenditure` and `spending` are combined as these are often used for individual farmers' expenses. `rural development` is limited with *agricultural terms* as it is wider than our interpretation (e.g. it can refer to poverty alleviation in rural areas, whereas we interpret this target to be focused on agriculture). 
 
 ```py
 TS =
@@ -774,6 +774,7 @@ TS =
         ("investm*" OR "investing" OR "invest" OR "finance" OR "financial support" OR "financing" OR "funding"
         OR "ODA" OR "cooperation fund$" OR "development spending"
         OR (("research" OR "governm*" OR "public" OR "sector") NEAR/3 ("expenditure" OR "spending"))
+        OR "international development"
         OR
           (
             ("international" OR "development" OR "foreign" OR "intercontinental"
@@ -786,13 +787,15 @@ TS =
           )
         )
         AND
-            ("rural infrastructure"
+            ("rural infrastructure" OR "rural tech*"
+            OR ("rural development" AND ("agri*" OR "agro*" OR "smallhold*" OR "farm*"))
+            OR "agricultur* development" OR "development of agriculture"
             OR "agronom*" OR "agroecolog*" OR "agro ecolog*" OR "agricultural sector"
             OR "plant bank$" OR "seed bank$" OR "gene bank$" OR "genebank$" OR "germplasm bank$" OR "cryobank$"
             OR
               (
                 ("infrastructure" OR "technolog*" OR "biotech*" OR "research" OR "science$" OR "innovation" OR "R&D")
-                NEAR/5 ("agricultur*" OR "smallhold*" OR "small hold*" OR "farm*" OR "irrigation" OR "agri food" OR "agrifood" OR "aquaculture" OR "mariculture")
+                NEAR/5 ("agricultur*" OR "smallhold*" OR "small hold*" OR "farm*" OR "irrigation" OR "agri food" OR "agrifood" OR "agrofood" OR "aquaculture" OR "mariculture")
               )                  
             )
       )

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -12,7 +12,7 @@ End hunger, achieve food security and improved nutrition and promote sustainable
 
 ## 1. Full query
 
-Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters, publication year = last 5 years): https://www.webofscience.com/wos/woscc/summary/60d089aa-b5e3-47e5-bc1c-609481d45120-a8382a58/relevance/1
+Results of the full search in its current state can be viewed on Web of Science by clicking here (no filters, publication year = last 5 years): https://www.webofscience.com/wos/woscc/summary/e89d2bcb-a8d0-414b-aff5-c41978ef9113-b76d297a/relevance/1
 
 ## 2. General notes
 
@@ -937,9 +937,9 @@ NOT
 
 * Testing v1.2.2: Project group; see documentation https://doi.org/10.5281/zenodo.8386611
 
-* v1.3.0: Caroline S. Armitage (Aug-Sep 2023), minor review Eli Heldaas Seland.
+* v2.0.0: Caroline S. Armitage (Aug-Sep 2023), minor review Eli Heldaas Seland.
 
-Specialist input: Awaiting specialist input.
+Specialist input: Awaiting.
 
 ## 5. Footnotes
 

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -47,7 +47,7 @@ This target is interpreted to cover research about
 * Access/right to food, food security, and food safety (phrase 2)
 * Food supplies and food supply chains (phrase 3)
 
-Some of these topics may partially overlap with 2.2. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nuritional *security*). Research topics such as nutritional security, free school meals and undernutrition may cover both areas (i.e. address that people have enough food, and that it is of sufficient nutritional quality).
+Some of these topics may partially overlap with 2.2. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nutritional *security*). Research topics such as nutritional security, free school meals and undernutrition may cover both areas (i.e. address that people have enough food, and that it is of sufficient nutritional quality).
 
 It consists of 3 phrases. Phrase 3 uses terms which need to be combined with human terms.
 
@@ -116,7 +116,7 @@ This target is interpreted to cover research about
 - the nutritional quality of food
 - malnutrition, and the nutritional status for all people (including elements specific to children, girls, the elderly and pregnant women). Malnutrition includes both underweight and overweight (<a id="WHOmalnut">[WHO, 2021](#f4)</a>); this WHO factsheet was used to add terms, including specific micronutrients of worldwide importance (iodine, iron, vitamin A).
 
-Some of these topics partially overlap with 2.1, which covers access to food/food insecurity. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nuritional *security*). Research topics such as nutritional security, free school meals and undernutrition may cover both areas (i.e. address that people have enough food, and that it is of sufficient nutritional quality).
+Some of these topics partially overlap with 2.1, which covers access to food/food insecurity. Nutritional quality of food and nutritional status of people is covered in 2.2 (e.g. nutritional *quality*); 2.1 is interpreted to focus on access-related issues (e.g. nutritional *security*). Research topics such as nutritional security, free school meals and undernutrition may cover both areas (i.e. address that people have enough food, and that it is of sufficient nutritional quality).
 
 This query consists of 3 phrases. Phrase 3 is for terms which need to be combined with human terms.
 

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -209,7 +209,7 @@ This query consists of 1 phrase. The elements of the phrase are: *productivity/a
   TS=
   (
     (
-      ("intensification" NEAR/5 ("smallhold*" OR "sustainable" OR "agroecolog*" OR "ecolog*"))  
+      ("intensification" NEAR/5 ("smallhold*" OR "small hold*" OR "small farm*" OR "family farm*" OR "family run farm*" OR "family owned farm*" OR "sustainable" OR "agroecolog*" OR "ecolog*"))  
       OR "production" OR "productivity" OR "yield$" OR "agricultural output$" OR "farm output$"
       OR "livelihood$" OR "income$" OR "profit*" OR "revenue" OR "economic viability"
       OR "value addition" OR "diversification" OR "non-farm employment" OR "off-farm employment" OR "off farm income"
@@ -220,7 +220,7 @@ This query consists of 1 phrase. The elements of the phrase are: *productivity/a
       OR "land grab*" OR "tenure insecurity"
       )
       AND
-          ("smallhold*" OR "small farm*" OR "family farm*" OR "family run farm*" OR "family owned farm*" OR "home gardening"
+          ("smallhold*" OR "small hold*" OR "small farm*" OR "family farm*" OR "family run farm*" OR "family owned farm*" OR "home gardening"
           OR
             (
               ("small-scale" OR "indigenous" OR "homestead*" OR "subsistence")
@@ -261,7 +261,7 @@ This target is interpreted to cover research about
 Increasing productivity of all food production systems (i.e. without reference to sustainable/resilient practices) was not considered relevant in v1. However, the SDG indicator metadata clearly classes increased productivity as part of sustainability. Thus, it is included now.
 > "Maintaining or improving the output over time relative to the area of land used is an important aspect in  sustainability  for  a  range  of  reasons.  [...]. In a broader sense, an increase in the level of  land  productivity  enables  higher  production  while  reducing  pressure  on  increasingly  scarce  land  resources,  commonly  linked  to  deforestation  and  associated  losses  of  ecosystem  services  and biodiversity." (<a id="SDGindmetadata">[Statistics Division, 2021b, Indicator 2.4.1](#f9)</a>).
 
-Under "food production systems" we include types of agriculture, fishing and aquaculture. We do not include processing, storage, distribution, and markets, which can be considered part of a wider "sustainable food system" (<a id="SFS">[e.g. Annex 2, Annex 3 in One Planet network Sustainable Food Systems (SFS) Programme, 2020](#f8)</a>). Thus concepts such as food sovereignty are too wide. Types of farming system were expanded using MeSH (NIH) and Emtree (Embase database, Elsevier) subject vocabularies. Specific types of crops and livestock were further expanded using FAO statistical year book (<a id="FAO2013">[FAO, 2013](#f2)</a>). For crops, those listed as major crops or "important food crops" are included, while oil crops were excluded (not being food). Some specific types are covered by generic terms: e.g. Root crops are covered by `crops`, and terms such as `farm*` will cover types of farming in two words e.g. forest farms, family farms, fish farming.
+Under "food production systems" we include types of agriculture, fishing and aquaculture. We do not include processing, storage, distribution, and markets, which can be considered part of a wider "sustainable food system" (<a id="SFS">[e.g. Annex 2, Annex 3 in One Planet network Sustainable Food Systems (SFS) Programme, 2020](#f8)</a>)  - unless they are connected to agriculture under umbrella terms such as `agrifood`. Thus concepts such as food sovereignty are too wide. Types of farming system were expanded using MeSH (NIH) and Emtree (Embase database, Elsevier) subject vocabularies. Specific types of crops and livestock were further expanded using FAO statistical year book (<a id="FAO2013">[FAO, 2013](#f2)</a>). For crops, those listed as major crops or "important food crops" are included, while oil crops were excluded (not being food). Some specific types are covered by generic terms: e.g. Root crops are covered by `crops`, and terms such as `farm*` will cover types of farming in two words e.g. forest farms, family farms, fish farming.
 
 This query consists of 6 phrases.
 
@@ -273,8 +273,9 @@ The elements of the phrase are: *food production systems + productivity*.
 TS=
 (
   (
-      ("food production" OR "food grower$"
-      OR "farm*" OR "agricultur*" OR "ecoagricultur*" OR "eco agricultur*" OR "permaculture"
+      ("food production" OR "food grower$" OR "agro food" OR "agrifood" OR "agri food"
+      OR "farm*" OR "agricultur*" OR "smallhold*" OR "small hold*"
+      OR "ecoagricultur*" OR "eco agricultur*" OR "permaculture"
       OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoral*"
       OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
       OR "aquaculture" OR "fish farm*"
@@ -310,8 +311,9 @@ In the *resilience* terms, `tolera*` is a particularly influential term that inc
 TS=
 (
   (
-      ("food production" OR "food grower$" OR "agro food"
-      OR "farm*" OR "agricultur*" OR "ecoagricultur*" OR "eco agricultur*" OR "permaculture"
+      ("food production" OR "food grower$" OR "agro food" OR "agrifood" OR "agri food"
+      OR "farm*" OR "agricultur*" OR "smallhold*" OR "small hold*"
+      OR "ecoagricultur*" OR "eco agricultur*" OR "permaculture"
       OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoralist$"
       OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
       OR "aquaculture" OR "fisher*" OR "fish farm*"
@@ -345,8 +347,9 @@ The *disaster* terms were taken from a standardised list we used across the SDGs
 TS=
 (
   (
-      ("food production" OR "food grower$" OR "agro food"
-      OR "farm*" OR "agricultur*" OR "ecoagricultur*" OR "eco agricultur*" OR "permaculture"
+      ("food production" OR "food grower$" OR "agro food" OR "agrifood" OR "agri food"
+      OR "farm*" OR "agricultur*" OR "smallhold*" OR "small hold*" 
+      OR "ecoagricultur*" OR "eco agricultur*" OR "permaculture"
       OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoralist$"
       OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
       OR "aquaculture" OR "fisher*" OR "fish farm*"
@@ -405,8 +408,8 @@ OR
 TS=
 (
   (
-    ("food production" OR "food grower$" OR "agri food"
-    OR "farm*" OR "agricultur*"
+    ("food production" OR "food grower$" OR "agro food" OR "agrifood" OR "agri food"
+    OR "farm*" OR "agricultur*" OR "smallhold*" OR "small hold*"
     OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoral*"
     OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
     OR "aquaculture" OR "fisher*" OR "fish farm*"
@@ -438,8 +441,9 @@ The elements of the phrase are: *food production systems + ecosystems and soil*.
 ```py
 TS=
 (
-    ("food production" OR "food grower$" OR "agri food"
-    OR "farm*" OR "agricultur*" OR "permaculture"
+    ("food production" OR "food grower$" OR "agro food" OR "agrifood" OR "agri food"
+    OR "farm*" OR "agricultur*" OR "smallhold*" OR "small hold*"
+    OR "permaculture"
     OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoral*"
     OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
     OR "aquaculture" OR "fisher*" OR "fish farm*"
@@ -469,8 +473,9 @@ Types of land/soil degradation are taken from <a id="FAO2014">[FAO (2014)](#f7)<
 ```py
 TS=
 (
-  ("food production" OR "food grower$" OR "agri food"
-  OR "farm*" OR "agricultur*" OR "permaculture"
+  ("food production" OR "food grower$" OR "agro food" OR "agrifood" OR "agri food"
+  OR "farm*" OR "agricultur*" OR "smallhold*" OR "small hold*"
+  OR "permaculture"
   OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoral*"
   OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
   OR "aquaculture" OR "fisher*" OR "fish farm*"
@@ -574,6 +579,7 @@ TS=
         ("genetic diversity" OR "genetic resource$")
         NEAR/15
             ("agricultur*" OR "domestic*" OR "farming" OR "farm$" OR "farmer$" OR "cultiva*" OR "permaculture"
+            OR "smallhold*" OR "small hold*"
             OR "cropping system$" OR "orchard$"
             OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
             OR "aquaculture"
@@ -619,6 +625,7 @@ TS=
       )  
       NEAR/15
           ("agricultur*" OR "farming" OR "farm$" OR "farmer$" OR "cultiva*" OR "permaculture"
+          OR "smallhold*" OR "small hold*"
           OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
           OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
           OR "aquaculture"
@@ -665,6 +672,7 @@ TS=
   AND
       ("food"
       OR "agricultur*" OR "domestic*" OR "farming" OR "farm$" OR "farmer$" OR "cultivar$" OR "permaculture"
+      OR "smallhold*" OR "small hold*"
       OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
       OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
       OR "aquaculture"
@@ -696,6 +704,7 @@ TS =
     AND
         ("food"
         OR "agricultur*" OR "domestic*" OR "farming" OR "farm$" OR "farmer$" OR "cultiva*" OR "permaculture"
+        OR "smallhold*" OR "small hold*"
         OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
         OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
         OR "aquaculture"
@@ -758,7 +767,7 @@ TS =
             OR
               (
                 ("infrastructure" OR "technolog*" OR "biotech*" OR "research" OR "science$" OR "innovation" OR "R&D")
-                NEAR/3 ("agricultur*" OR "farm*" OR "irrigation" OR "agri food" OR "agrifood")
+                NEAR/3 ("agricultur*" OR "smallhold*" OR "small hold*" OR "farm*" OR "irrigation" OR "agri food" OR "agrifood")
               )                  
             )
       )

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -230,7 +230,7 @@ This query consists of 1 phrase. The elements of the phrase are: *productivity/a
                   OR "agricultur*" OR "farm*" OR "permaculture"
                   OR "cropping system$" OR "orchard$" OR "arable land$"
                   OR "pasture$" OR "pastoral*" OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-                  OR "aquaculture" OR "fisher*" OR "fish farm*"
+                  OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
                   )
                 OR
                   (
@@ -278,7 +278,7 @@ TS=
       OR "ecoagricultur*" OR "eco agricultur*" OR "permaculture"
       OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoral*"
       OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-      OR "aquaculture" OR "fish farm*"
+      OR "aquaculture" OR "fish farm*" OR "mariculture"
       OR
         (
           ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
@@ -324,7 +324,7 @@ TS=
       OR "ecoagricultur*" OR "eco agricultur*" OR "permaculture"
       OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoralist$"
       OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-      OR "aquaculture" OR "fisher*" OR "fish farm*"
+      OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
       OR "crop$" OR "cereal$" OR "rice" OR "wheat" OR "maize"
       OR "livestock" OR "cattle" OR "sheep" OR "poultry" OR "chicken$" OR "pig$" OR "goat$"
       OR
@@ -363,7 +363,7 @@ TS=
       OR "ecoagricultur*" OR "eco agricultur*" OR "permaculture"
       OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoralist$"
       OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-      OR "aquaculture" OR "fisher*" OR "fish farm*"
+      OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
       OR "crop$" OR "cereal$" OR "rice" OR "wheat" OR "maize"
       OR "livestock" OR "cattle" OR "sheep" OR "poultry" OR "chicken$" OR "pig$" OR "goat$"
       OR
@@ -423,7 +423,7 @@ TS=
     OR "farm*" OR "agricultur*" OR "smallhold*" OR "small hold*"
     OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoral*"
     OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-    OR "aquaculture" OR "fisher*" OR "fish farm*"
+    OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
     OR
       (
         ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
@@ -457,7 +457,7 @@ TS=
     OR "permaculture"
     OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoral*"
     OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-    OR "aquaculture" OR "fisher*" OR "fish farm*"
+    OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
     OR
       (
         ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
@@ -490,7 +490,7 @@ TS=
   OR "permaculture"
   OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$" OR "pastoral*"
   OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-  OR "aquaculture" OR "fisher*" OR "fish farm*"
+  OR "aquaculture" OR "fisher*" OR "fish farm*" OR "mariculture"
   OR
     (
       ("crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
@@ -599,7 +599,7 @@ TS=
             OR "smallhold*" OR "small hold*"
             OR "permaculture" OR "cropping system$" OR "orchard$"
             OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-            OR "aquaculture"
+            OR "aquaculture" OR "mariculture"
             OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
             OR "livestock" OR "poultry" OR "cattle" OR "sheep" OR "pig$" OR "goat$" OR "chicken$" OR "duck$" OR "buffalo*"
             OR "landrace$" OR "wild relative$"
@@ -645,7 +645,7 @@ TS=
           OR "smallhold*" OR "small hold*"
           OR "permaculture" OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
           OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-          OR "aquaculture"
+          OR "aquaculture" OR "mariculture"
           OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
           OR "livestock" OR "poultry" OR "cattle" OR "sheep" OR "pig$" OR "goat$" OR "chicken$" OR "duck$" OR "buffalo*"     
           OR "landrace$" OR "wild relative$"
@@ -692,7 +692,7 @@ TS=
       OR "smallhold*" OR "small hold*"
       OR "permaculture" OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
       OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-      OR "aquaculture"
+      OR "aquaculture" OR "mariculture"
       OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
       OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
       OR "landrace$" OR "wild relative$"
@@ -724,7 +724,7 @@ TS =
         OR "smallhold*" OR "small hold*"
         OR "permaculture" OR "cropping system$" OR "orchard$" OR "arable land$" OR "pasture$"
         OR "agroforest*" OR "agro forest*" OR "silvopastur*" OR "silvopastoral*"
-        OR "aquaculture"
+        OR "aquaculture" OR "mariculture"
         OR "crop$" OR "grain$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses"
         OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
         OR "landrace$" OR "wild relative$"
@@ -783,7 +783,7 @@ TS =
             OR
               (
                 ("infrastructure" OR "technolog*" OR "biotech*" OR "research" OR "science$" OR "innovation" OR "R&D")
-                NEAR/5 ("agricultur*" OR "smallhold*" OR "small hold*" OR "farm*" OR "irrigation" OR "agri food" OR "agrifood")
+                NEAR/5 ("agricultur*" OR "smallhold*" OR "small hold*" OR "farm*" OR "irrigation" OR "agri food" OR "agrifood" OR "aquaculture" OR "mariculture")
               )                  
             )
       )
@@ -795,10 +795,10 @@ TS =
       OR "low income countr*" OR "low income nation$" OR "lower income countr*" OR "lower income nation$"
       OR "poor countr*" OR "poor nation$" OR "poorer countr*" OR "poorer nation$"
       OR "lmic" OR "lmics" OR "third world" OR "global south" OR "lami countr*" OR "transitional countr*" OR "emerging economies" OR "emerging nation$"
-      OR  "Angola*" OR "Benin" OR "beninese" OR "Burkina Faso" OR "Burkina fasso" OR "burkinese" OR "burkinabe" OR "Burundi*" OR "Central African Republic" OR "Chad" OR "Comoros" OR "comoro islands" OR "iles comores" OR "Congo" OR "congolese" OR "Djibouti*" OR "Eritrea*" OR "Ethiopia*" OR "Gambia*" OR "Guinea" OR "Guinea-Bissau" OR "guinean" OR "Lesotho" OR "lesothan*" OR "Liberia*" OR "Madagasca*" OR "Malawi*" OR "Mali" OR "malian" OR "Mauritania*" OR "Mozambique" OR "mozambican$" OR "Niger" OR "Rwanda*" OR "Sao Tome and Principe" OR "Senegal*" OR "Sierra Leone*" OR "Somalia*" OR "South Sudan" OR "Sudan" OR "sudanese" OR "Togo" OR "togolese" OR "tongan" OR "Uganda*" OR "Tanzania*" OR "Zambia*" OR "Cambodia*" OR "Kiribati*" OR "Lao People’s democratic republic" OR "Laos" OR "Myanmar" OR "myanma" OR "Solomon islands" OR "Timor Leste" OR "Tuvalu*" OR "Vanuatu*" OR "Afghanistan" OR "afghan$" OR "Bangladesh*" OR "Bhutan*" OR "Nepal*" OR "Yemen*" OR "Haiti*"
+      OR "Angola*" OR "Benin" OR "beninese" OR "Burkina Faso" OR "Burkina fasso" OR "burkinese" OR "burkinabe" OR "Burundi*" OR "Central African Republic" OR "Chad" OR "Comoros" OR "comoro islands" OR "iles comores" OR "Congo" OR "congolese" OR "Djibouti*" OR "Eritrea*" OR "Ethiopia*" OR "Gambia*" OR "Guinea" OR "Guinea-Bissau" OR "guinean" OR "Lesotho" OR "lesothan*" OR "Liberia*" OR "Madagasca*" OR "Malawi*" OR "Mali" OR "malian" OR "Mauritania*" OR "Mozambique" OR "mozambican$" OR "Niger" OR "Rwanda*" OR "Sao Tome and Principe" OR "Senegal*" OR "Sierra Leone*" OR "Somalia*" OR "South Sudan" OR "Sudan" OR "sudanese" OR "Togo" OR "togolese" OR "tongan" OR "Uganda*" OR "Tanzania*" OR "Zambia*" OR "Cambodia*" OR "Kiribati*" OR "Lao People’s democratic republic" OR "Laos" OR "Myanmar" OR "myanma" OR "Solomon islands" OR "Timor Leste" OR "Tuvalu*" OR "Vanuatu*" OR "Afghanistan" OR "afghan$" OR "Bangladesh*" OR "Bhutan*" OR "Nepal*" OR "Yemen*" OR "Haiti*"
       OR  "Antigua and Barbuda" OR "Antigua & Barbuda" OR "antiguan$" OR "Bahamas" OR "Bahrain" OR "Barbados" OR "Belize" OR "Cabo Verde" OR "Cape Verde" OR "Comoros" OR "comoro islands" OR "iles comores" OR "Cuba" OR "cuban$" OR "Dominica*" OR "Dominican Republic" OR "Micronesia*" OR "Fiji" OR "fijian$" OR "Grenada*" OR "Guinea-Bissau" OR "Guyana*" OR "Haiti*" OR "Jamaica*" OR "Kiribati*" OR "Maldives" OR "maldivian$" OR "Marshall Islands" OR "Mauritius" OR "mauritian$" OR "Nauru*" OR "Palau*" OR "Papua New Guinea*" OR "Saint Kitts and Nevis" OR "st kitts and nevis" OR "Saint Lucia*" OR "St Lucia*" OR "Vincent and the Grenadines" OR "Vincent & the Grenadines" OR "Samoa*" OR "Sao Tome" OR "Seychelles" OR "seychellois*" OR "Singapore*" OR "Solomon Islands" OR "Surinam*" OR "Timor-Leste" OR "timorese" OR "Tonga*" OR "Trinidad and Tobago" OR "Trinidad & Tobago" OR "trinidadian$" OR "tobagonian$" OR "Tuvalu*" OR "Vanuatu*" OR "Anguilla*" OR "Aruba*" OR "Bermuda*" OR "Cayman Islands" OR "Northern Mariana$" OR "Cook Islands" OR "Curacao" OR "French Polynesia*" OR "Guadeloupe*" OR "Guam" OR "Martinique" OR "Montserrat" OR "New Caledonia*" OR "Niue" OR "Puerto Rico" OR "puerto rican" OR "Sint Maarten" OR "Turks and Caicos" OR "Turks & Caicos" OR "Virgin Islands"
-      OR  "Afghanistan" OR "afghan*" OR "Armenia*" OR "Azerbaijan*" OR "Bhutan" OR "bhutanese" OR "Bolivia*" OR "Botswana*" OR "Burkina Faso" OR "Burundi" OR "Central African Republic" OR "Chad" OR "Eswatini" OR "eswantian" OR "Ethiopia*" OR "Kazakhstan*" OR "kazakh" OR "Kyrgyzstan" OR "Kyrgyz*" OR "kirghizia" OR "kirgizstan" OR "Lao People’s Democratic Republic" OR "Laos" OR "Lesotho" OR "Malawi" OR "malawian" OR "Mali" OR "Mongolia*" OR "Nepal*" OR "Niger" OR "North Macedonia" OR "Republic of Macedonia" OR "Paraguay" OR "Moldova*" OR "Rwanda$" OR "South Sudan" OR "sudanese" OR "Swaziland" OR "Tajikistan" OR "tadjikistan" OR "tajikistani$" OR "Turkmenistan" OR "Uganda*" OR "Uzbekistan" OR "uzbekistani$" OR "Zambia" OR "zambian$" OR "Zimbabwe*"
-      OR   "albania*" OR "algeria*" OR "angola*" OR "argentina*" OR "azerbaijan*" OR "bahrain*" OR "belarus*" OR "byelarus*" OR "belorussia" OR "belize*" OR "honduras" OR "honduran" OR "dahomey" OR "bosnia*" OR "herzegovina*" OR "botswana*" OR "bechuanaland" OR "brazil*" OR "brasil*" OR "bulgaria*" OR "upper volta" OR "kampuchea" OR "khmer republic" OR "cameroon*" OR "cameroun" OR "ubangi shari" OR "chile*" OR "china" OR "chinese" OR "colombia*" OR "costa rica*" OR "cote d’ivoire" OR "cote divoire" OR "cote d ivoire" OR "ivory coast" OR "croatia*" OR "cyprus" OR "cypriot" OR "czech" OR "ecuador*" OR "egypt*" OR "united arab republic" OR "el salvador*" OR "estonia*" OR "eswatini" OR "swaziland" OR "swazi" OR "gabon" OR "gabonese" OR "gabonaise" OR "gambia*" OR "ghana*" OR "gibralta*" OR "greece" OR "greek" OR "honduras" OR "honduran$" OR "hungary" OR "hungarian$" OR "india" OR "indian$" OR "indonesia*" OR "iran" OR "iranian$" OR "iraq" OR "iraqi$" OR "isle of man" OR "jordan" OR "jordanian$" OR "kenya*" OR "korea*" OR "kosovo" OR "kosovan$" OR "latvia*" OR "lebanon" OR "lebanese" OR "libya*" OR "lithuania*" OR "macau" OR "macao" OR "macanese" OR "malagasy" OR "malaysia*" OR "malay federation" OR "malaya federation" OR "malta" OR "maltese" OR "mauritania" OR "mauritanian$" OR "mexico" OR "mexican$" OR "montenegr*" OR "morocco" OR "moroccan$" OR "namibia*" OR "netherlands antilles" OR "nicaragua*" OR "nigeria*" OR "oman" OR "omani$" OR "muscat" OR "pakistan*" OR "panama*" OR "papua new guinea*" OR "peru" OR "peruvian$" OR "philippine$" OR "philipine$" OR "phillipine$" OR "phillippine$" OR "filipino$" OR "filipina$" OR "poland" OR "polish" OR "portugal" OR "portugese" OR "romania*" OR "russia" OR "russian$" OR "polynesia*" OR "saudi arabia*" OR "serbia*" OR "slovakia*" OR "slovak republic" OR "slovenia*" OR "melanesia*" OR "south africa*" OR "sri lanka*" OR "dutch guiana" OR "netherlands guiana" OR "syria" OR "syrian$" OR "thailand" OR "thai" OR "tunisia*" OR "ukraine" OR "ukrainian$" OR "uruguay*" OR "venezuela*" OR "vietnam*" OR "west bank" OR "gaza" OR "palestine" OR "palestinian$" OR "yugoslavia*" OR "turkish" OR "turkey" OR "georgian*"
+      OR "Afghanistan" OR "afghan*" OR "Armenia*" OR "Azerbaijan*" OR "Bhutan" OR "bhutanese" OR "Bolivia*" OR "Botswana*" OR "Burkina Faso" OR "Burundi" OR "Central African Republic" OR "Chad" OR "Eswatini" OR "eswantian" OR "Ethiopia*" OR "Kazakhstan*" OR "kazakh" OR "Kyrgyzstan" OR "Kyrgyz*" OR "kirghizia" OR "kirgizstan" OR "Lao People’s Democratic Republic" OR "Laos" OR "Lesotho" OR "Malawi" OR "malawian" OR "Mali" OR "Mongolia*" OR "Nepal*" OR "Niger" OR "North Macedonia" OR "Republic of Macedonia" OR "Paraguay" OR "Moldova*" OR "Rwanda$" OR "South Sudan" OR "sudanese" OR "Swaziland" OR "Tajikistan" OR "tadjikistan" OR "tajikistani$" OR "Turkmenistan" OR "Uganda*" OR "Uzbekistan" OR "uzbekistani$" OR "Zambia" OR "zambian$" OR "Zimbabwe*"
+      OR "albania*" OR "algeria*" OR "angola*" OR "argentina*" OR "azerbaijan*" OR "bahrain*" OR "belarus*" OR "byelarus*" OR "belorussia" OR "belize*" OR "honduras" OR "honduran" OR "dahomey" OR "bosnia*" OR "herzegovina*" OR "botswana*" OR "bechuanaland" OR "brazil*" OR "brasil*" OR "bulgaria*" OR "upper volta" OR "kampuchea" OR "khmer republic" OR "cameroon*" OR "cameroun" OR "ubangi shari" OR "chile*" OR "china" OR "chinese" OR "colombia*" OR "costa rica*" OR "cote d’ivoire" OR "cote divoire" OR "cote d ivoire" OR "ivory coast" OR "croatia*" OR "cyprus" OR "cypriot" OR "czech" OR "ecuador*" OR "egypt*" OR "united arab republic" OR "el salvador*" OR "estonia*" OR "eswatini" OR "swaziland" OR "swazi" OR "gabon" OR "gabonese" OR "gabonaise" OR "gambia*" OR "ghana*" OR "gibralta*" OR "greece" OR "greek" OR "honduras" OR "honduran$" OR "hungary" OR "hungarian$" OR "india" OR "indian$" OR "indonesia*" OR "iran" OR "iranian$" OR "iraq" OR "iraqi$" OR "isle of man" OR "jordan" OR "jordanian$" OR "kenya*" OR "korea*" OR "kosovo" OR "kosovan$" OR "latvia*" OR "lebanon" OR "lebanese" OR "libya*" OR "lithuania*" OR "macau" OR "macao" OR "macanese" OR "malagasy" OR "malaysia*" OR "malay federation" OR "malaya federation" OR "malta" OR "maltese" OR "mauritania" OR "mauritanian$" OR "mexico" OR "mexican$" OR "montenegr*" OR "morocco" OR "moroccan$" OR "namibia*" OR "netherlands antilles" OR "nicaragua*" OR "nigeria*" OR "oman" OR "omani$" OR "muscat" OR "pakistan*" OR "panama*" OR "papua new guinea*" OR "peru" OR "peruvian$" OR "philippine$" OR "philipine$" OR "phillipine$" OR "phillippine$" OR "filipino$" OR "filipina$" OR "poland" OR "polish" OR "portugal" OR "portugese" OR "romania*" OR "russia" OR "russian$" OR "polynesia*" OR "saudi arabia*" OR "serbia*" OR "slovakia*" OR "slovak republic" OR "slovenia*" OR "melanesia*" OR "south africa*" OR "sri lanka*" OR "dutch guiana" OR "netherlands guiana" OR "syria" OR "syrian$" OR "thailand" OR "thai" OR "tunisia*" OR "ukraine" OR "ukrainian$" OR "uruguay*" OR "venezuela*" OR "vietnam*" OR "west bank" OR "gaza" OR "palestine" OR "palestinian$" OR "yugoslavia*" OR "turkish" OR "turkey" OR "georgian*"
       )
 )
 
@@ -925,6 +925,8 @@ NOT
 * v1.0.0 Caroline S. Armitage (Oct 2021-Oct 2022)
 
 * Internal review: Eli Heldaas Seland, Marta Lorenz (March 2022); Eli Heldaas Seland (minor review Oct 2022)
+
+* Revision after testing: Caroline S. Armitage (July 2023)
 
 Specialist input: Awaiting specialist input.
 

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -305,7 +305,7 @@ The elements of the phrase are: *food production systems + resilience/vulnerabil
 
 In the *food production system* terms, production systems and species are included (i.e. species are split from production where possible so that both resilience for the species and the production system will be covered). Some species remain linked to production to avoid irrelevant results (e.g. vegetable intake and psychological resilience). `pastoral*` is limited in this phrase, as it finds results from other uses (pastoral care, religion studies).
 
-In the *resilience* terms, `tolera*` is a particularly influential term that increases results ("drought tolerance" of crops being a common research theme). `climate smart agriculture` is a term used for an approach specifically addressing climate change.
+In the *resilience* terms, `climate smart agriculture` is a term used for an approach specifically addressing climate change.
 
 ```py
 TS=
@@ -327,7 +327,8 @@ TS=
       )
       NEAR/15
             ("climate smart agriculture" OR "resilien*"
-            OR (("disaster$" OR "risk$") NEAR/3 ("plan*" OR "strateg*" OR "relief" OR "manag*"))
+            OR "risk reduction"
+            OR (("disaster$" OR "risk$") NEAR/3 ("plan*" OR "strateg*" OR "relief" OR "manag*" OR "program*"))
             OR "vulnerability"
             )  
   )
@@ -340,6 +341,8 @@ TS=
 The elements of the phrase are: *food production systems + adaptation/coping/preparedness + disaster/climate change*.
 
 The *food production system* terms are the same as phrase 2.  These *disaster/climate change* terms include natural disasters, climate, market volatility, civil and political unrest (examples of risks in <a id="FAO2014">[FAO, 2014](#f7)</a>).
+
+In the *adaptation/coping/preparedness* terms, `tolera*` is a particularly influential term that increases results ("drought tolerance" of crops being a common research theme). 
 
 The *disaster* terms were taken from a standardised list we used across the SDGs, which was developed based on selected hazards listed in <a id="Murray">[Murray et al. (2021)](#f15)</a>.
 
@@ -363,9 +366,9 @@ TS=
       )
       NEAR/15
           (
-            ("adapt*" OR "mitigat*" OR "protect*" OR "avoid*" OR "limit" OR "prevent*"
-            OR "plan" OR "planning" OR "plans" OR "policy" OR "policies" OR "strateg*" OR "framework$" OR "governance" OR "legislat*"
-            OR "cope" OR "coping" OR "tolera*" OR "preparedness" OR "early warning"
+            ("mitigat*" OR "protect*" OR "avoid*" OR "limit" OR "prevent*" OR "preparedness" OR "early warning"
+            OR "sendai" OR "plan" OR "planning" OR "plans" OR "policy" OR "policies" OR "strateg*" OR "framework$" OR "governance" OR "legislat*" OR "programme$"
+            OR "cope" OR "coping" OR "tolera*" OR "adapt*" OR "manag*" OR "relief"
             )
             NEAR/5
                 ("climate change" OR "climatic change$" OR "global warming" OR "changing climate"

--- a/SDG02_query_topic_WoS.md
+++ b/SDG02_query_topic_WoS.md
@@ -253,7 +253,7 @@ This query consists of 1 phrase. The elements of the phrase are: *productivity/a
 > 2.4.1 Proportion of agricultural area under productive and sustainable agriculture
 
 This target is interpreted to cover research about
-* productivity of food production systems (phrase 1)
+* productivity/yield of food production systems (phrase 1)
 * resilient food production systems/agricultural practices, including adaptation and preparedness of food production systems/species to climate change and disasters (phrases 2,3)
 * sustainable food production systems/practices (outside of resilience; phrase 4)
 * food production systems and soil quality/ecosystem health (phrase 5,6)
@@ -267,7 +267,7 @@ This query consists of 6 phrases.
 
 #### Phrase 1
 
-The elements of the phrase are: *food production systems + productivity*. 
+The elements of the phrase are: *food production systems + productivity*. Here, in contrast to the action approach, `intensification` is allowed to stand alone (without `"sustainable" OR "agroecolog*" OR "ecolog*"`). `grain yield$` is included as a phrase, rather than being combined with NEAR, because otherwise this results in a high number of results from metallurgy. `yield$` is included in 2 parts of the string, meaning that mentioning e.g. "rice yields" is enough to be included. 
 
 ```py
 TS=
@@ -285,10 +285,18 @@ TS=
           OR "livestock" OR "fish" OR "cattle" OR "sheep" OR "poultry" OR "pig$" OR "goat$" OR "chicken$" OR "buffalo*" OR "duck$"
           )
           NEAR/5 ("production" OR "producer$" OR "grower$" OR "herder$" OR "herding" OR "ranch*" OR "plantation$")
-        )      
+        )  
+      OR
+        (
+          ("crop$" OR "vegetable$" OR "fruit$" OR "cereal$" OR "rice" OR "wheat" OR "maize" OR "pulses")
+          NEAR/5 "yield$"
+        )     
+      OR "grain yield$"
       )
       NEAR/15
-          ("intensification" OR "production" OR "productivity" OR "efficiency" OR "yield$" OR "agricultural output$" OR "farm output$")  
+          ("intensification" OR "production" OR "productivity" OR "efficiency" 
+          OR "yield$" OR "agricultural output$" OR "farm output$"
+          )  
   )
   NOT ("solar farm*" OR "wind farm*" OR "power farm*")
 )


### PR DESCRIPTION
# Edit SDG2

## Target 2.1
- Tidied up the interpretations - clarified that nutrition (i.e. nutritional quality) is now in 2.2. Nutrition security (i.e. access-related) are still in 2.1.
- Phrase 1: Added `"child* hunger" OR "undernourishment"`. Simplified the double NOT statement to a single NOT (was unnecessary).
- Phrase 2: Removed `"nutrition* quality" OR "nutrition sensitive agriculture"` - now only included in 2.2. Added `"school feeding" OR "free school meals" OR "food stamp program*" OR "nutrition assistance" OR "food assistance"`
- Phrase 3: Removed `"nutritional value" OR "nutrient content" OR "nutritional content"`- now only included in 2.2 (phrase 3).

## Target 2.2
- Tidied up the interpretations - clarified that nutrition (i.e. nutritional quality) is now in 2.2. Nutrition security (i.e. access-related) are still in 2.1.
- Phrase 2, *topic approach*: increased NEAR distance between nutrition and person groups from `NEAR/5` to `NEAR/15`
- Phrase 2, *topic approach*: Added `("nutrition*" AND ("school feeding" OR "free school meals" OR "food stamp program*" OR "food assistance"))`; *action approach*: Added `("nutrition*" NEAR/15 ("school feeding" OR "free school meals" OR "food stamp program*" OR "food assistance"))`
- Phrase 3: Added `"nutritional value" OR "nutrient content" OR "nutritional content"`. *Action approach*: added positive action terms to go with these nutritional terms.

## Target 2.3

* Added `small farm*` as synonym for small-scale farms
* Added `small hold*` as variant of "smallhold*"
* Added `mariculture` as a synonym for aquaculture, and `legume$` as a synonym for pulses

## Target 2.4

* Cleaned up variation between phrases in use of `agri food` vs. `agro food` - now all phrases contain both: Added `"agro food" OR "agrifood" OR "agri food" OR "smallhold*" OR "small hold*"` in all phrases as synonyms for agriculture. Added `mariculture` and `legume$` in all phrases for agriculture. 
* Phrase 1: Added `yield$` as a synonym in the producers/production terms combined with terms for crops (`"crop$" OR "vegetable$" ...`) to allow works mentioning e.g. "rice yield" to be included. `grain yield` was taken out and included as a phrase to avoid works from metallurgy.
* Phrase 2: Added risk/disaster reduction and "program*" so it now contains `"risk reduction" OR "disaster reduction" OR (("disaster$" OR "risk$") NEAR/3 ("plan*" OR "strateg*" OR "relief" OR "manag*" OR "program*"))`
* Phrase 3: Added `"programme$" OR "relief" OR "manag*" OR "sendai"` to the *adaptation/coping/preparedness* terms
* Phrase 4: Added `"ecosystem based"` to the sustainable terms; added `"fodder" OR "animal feed" OR "fish feed"` to the agriculture terms.
* Phrase 5: Added `"soil improv*"`. Limited `ecosystem$` (previously alone + agriculture) so that it has to be with `"health*" OR "resilien*" OR "function*" OR "restor*" OR "quality" OR "stability" OR "impact$" OR "effect$" OR "affect*"`, as it was too generic
* Phrase 6: Added `vulnerab*` as a *loss/decline* term with ecosystems; Added `"environmental impact$" OR "environmental footprint"`

## Target 2.5

* Added `"smallhold*" OR "small hold*"`, `farmed`, `mariculture` and `legume$` as terms for farming in phrases 2,3,4,5
* Phrase 2: Changed "genetic diversity" to a NEAR phrase, `("genetic" NEAR/2 "diversity")`
* Phrase 3: Added plurals of some genebank terms to stand alone (see documentation): `OR "gene bank" OR "genebank" OR "germplasm bank" OR "cryobank"`
* Phrase 4: Added `availability` as an *access* term. "available" was not used as this often referred to study methods.

## Target 2.a

* Added `"smallhold*" OR "small hold*" OR "agrofood"` and `aquaculture OR mariculture` as synonyms for farming. 
* Added `"rural tech*" OR "agricultur* development" OR "development of agriculture"` as rural infrastructure/tech terms. Added also `("rural development" AND ("agri*" OR "agro*" OR "smallhold*" OR "farm*"))` 
* Added `"global" OR "intercontinental" OR "european" OR "asian" OR "africa*" OR "latin america*" OR "pacific"` as synonyms for international (when combined with funds/collaboration etc.). Added also `"international development"` as a stand-alone term.
* Changed `NEAR/3` to `NEAR/5` for the combination of agriculture + infrastructure
* Loosened the restriction of "government or public" on investment to get better recall - all investment is considered relevant (matches interpretation better). Some terms are still combined, such as spending and expenditure. New string section is: `"investm*" OR "investing" OR "invest" OR "finance" OR "financial support" OR "financing" OR "funding" ...  OR (("research" OR "governm*" OR "public" OR "sector") NEAR/3 ("expenditure" OR "spending"))`

## Target 2.b
Phrase 2:
* Added `sanction$` as a *distortion* term
* Added `import$` as a *markets* term
* Added `legume$` and `"aquaculture" OR "mariculture"` as agriculture terms

## Target 2.c
* Added `legume$`  and `"aquaculture" OR "mariculture"` as agriculture terms